### PR TITLE
change reference from raybellwaves to xarray-contrib

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,12 @@
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.2.3
+    hooks:
+      - id: no-commit-to-branch
+      - id: check-docstring-first
+      - id: end-of-file-fixer
+      - id: check-merge-conflict
+
   # isort should run before black as black sometimes tweaks the isort output
   - repo: https://github.com/PyCQA/isort
     rev: 5.5.3

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -123,7 +123,7 @@ xskillscore v0.0.13 (2020-03-17)
 
 Bug Fixes
 ~~~~~~~~~
-- Fixes https://github.com/raybellwaves/xskillscore/issues/79 `assignment destination is read-only`
+- Fixes https://github.com/xarray-contrib/xskillscore/issues/79 `assignment destination is read-only`
   error when ``skipna=True`` and weights are passed. `Andrew Huang`_
 
 

--- a/HOWTOCONTRIBUTE.rst
+++ b/HOWTOCONTRIBUTE.rst
@@ -4,7 +4,7 @@ Contribution Guide
 
 Contributions are highly welcomed and appreciated.  Every little help counts,
 so do not hesitate! You can make a high impact on ``xskillscore`` just by using it and
-reporting `issues <https://github.com/raybellwaves/xskillscore/issues>`__.
+reporting `issues <https://github.com/xarray-contrib/xskillscore/issues>`__.
 
 The following sections cover some general guidelines
 regarding development in ``xskillscore`` for maintainers and contributors.
@@ -27,7 +27,7 @@ Feature requests and feedback
 
 We are eager to hear about your requests for new features and any suggestions about the
 API, infrastructure, and so on. Feel free to submit these as
-`issues <https://github.com/raybellwaves/xskillscore/issues/new?assignees=&labels=feature+request&template=ISSUE.md>`__
+`issues <https://github.com/xarray-contrib/xskillscore/issues/new?assignees=&labels=feature+request&template=ISSUE.md>`__
 with the label "feature request."
 
 Please make sure to explain in detail how the feature should work and keep the scope as
@@ -40,7 +40,7 @@ Report bugs
 -----------
 
 Report bugs for ``xskillscore`` in the
-`issue tracker <https://github.com/raybellwaves/xskillscore/issues/new?assignees=&labels=bug&template=ISSUE.md>`_
+`issue tracker <https://github.com/xarray-contrib/xskillscore/issues/new?assignees=&labels=bug&template=ISSUE.md>`_
 with the label "bug".
 
 If you are reporting a bug, please include:
@@ -59,7 +59,7 @@ that is a very useful commit to make as well, even if you cannot fix the bug its
 Fix bugs
 --------
 
-Look through the `GitHub issues for bugs <https://github.com/raybellwaves/xskillscore/labels/bug>`_.
+Look through the `GitHub issues for bugs <https://github.com/xarray-contrib/xskillscore/labels/bug>`_.
 
 Talk to developers to find out how you can fix specific bugs.
 
@@ -105,7 +105,7 @@ Preparing Pull Requests
 
 
 #. Fork the
-   `xskillscore GitHub repository <https://github.com/raybellwaves/xskillscore>`__.  It's
+   `xskillscore GitHub repository <https://github.com/xarray-contrib/xskillscore>`__.  It's
    fine to use ``xskillscore`` as your fork repository name because it will live
    under your user.
 
@@ -114,7 +114,7 @@ Preparing Pull Requests
 
     $ git clone git@github.com:YOUR_GITHUB_USERNAME/xskillscore.git
     $ cd xskillscore
-    $ git remote add upstream git@github.com:raybellwaves/xskillscore.git
+    $ git remote add upstream git@github.com:xarray-contrib/xskillscore.git
 
     # now, to fix a bug or add feature create your own branch off "master":
 

--- a/README.rst
+++ b/README.rst
@@ -1,14 +1,14 @@
 xskillscore: Metrics for verifying forecasts
 ============================================
 
-.. image:: https://travis-ci.org/raybellwaves/xskillscore.svg?branch=master
-   :target: https://travis-ci.org/raybellwaves/xskillscore
+.. image:: https://travis-ci.org/xarray-contrib/xskillscore.svg?branch=master
+   :target: https://travis-ci.org/xarray-contrib/xskillscore
 .. image:: https://img.shields.io/pypi/v/xskillscore.svg
    :target: https://pypi.python.org/pypi/xskillscore/
 .. image:: https://anaconda.org/conda-forge/xskillscore/badges/version.svg
    :target: https://anaconda.org/conda-forge/xskillscore/
-.. image:: https://coveralls.io/repos/github/raybellwaves/xskillscore/badge.svg?branch=master
-   :target: https://coveralls.io/github/raybellwaves/xskillscore?branch=master
+.. image:: https://coveralls.io/repos/github/xarray-contrib/xskillscore/badge.svg?branch=master
+   :target: https://coveralls.io/github/xarray-contrib/xskillscore?branch=master
 .. image:: https://img.shields.io/readthedocs/xskillscore/stable.svg?style=flat
    :target: https://xskillscore.readthedocs.io/en/stable/?badge=stable
 .. image:: https://img.shields.io/badge/benchmarked%20by-asv-green.svg?style=flat
@@ -32,7 +32,7 @@ or
 
 or
 
-``$ pip install git+https://github.com/raybellwaves/xskillscore``
+``$ pip install git+https://github.com/xarray-contrib/xskillscore``
 
 Documentation
 -------------

--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -7,7 +7,7 @@
     "project": "project",
 
     // The project's homepage
-    "project_url": "https://github.com/raybellwaves/xskillscore",
+    "project_url": "https://github.com/xarray-contrib/xskillscore",
 
     // The URL or local path of the source code repository for the
     // project being benchmarked

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,8 +44,8 @@ extensions = [
 ]
 
 extlinks = {
-    "issue": ("https://github.com/raybellwaves/xskillscore/issues/%s", "GH#"),
-    "pr": ("https://github.com/raybellwaves/xskillscore/pull/%s", "GH#"),
+    "issue": ("https://github.com/xarray-contrib/xskillscore/issues/%s", "GH#"),
+    "pr": ("https://github.com/xarray-contrib/xskillscore/pull/%s", "GH#"),
 }
 
 nbsphinx_timeout = 60

--- a/docs/source/contributors.rst
+++ b/docs/source/contributors.rst
@@ -10,4 +10,4 @@ Contributors
 * Riley X. Brady (`github <https://github.com/bradyrx/>`__)
 
 For a list of all the contributions, see the github
-`contribution graph <https://github.com/raybellwaves/xskillscore/graphs/contributors>`__.
+`contribution graph <https://github.com/xarray-contrib/xskillscore/graphs/contributors>`__.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,8 +1,8 @@
 xskillscore: Metrics for verifying forecasts
 ============================================
 
-.. image:: https://travis-ci.org/raybellwaves/xskillscore.svg?branch=master
-   :target: https://travis-ci.org/raybellwaves/xskillscore
+.. image:: https://travis-ci.org/xarray-contrib/xskillscore.svg?branch=master
+   :target: https://travis-ci.org/xarray-contrib/xskillscore
 
 .. image:: https://img.shields.io/pypi/v/xskillscore.svg
    :target: https://pypi.python.org/pypi/xskillscore/
@@ -10,8 +10,8 @@ xskillscore: Metrics for verifying forecasts
 .. image:: https://anaconda.org/conda-forge/xskillscore/badges/version.svg
    :target: https://anaconda.org/conda-forge/xskillscore/
 
-.. image:: https://coveralls.io/repos/github/raybellwaves/xskillscore/badge.svg?branch=master
-   :target: https://coveralls.io/github/raybellwaves/xskillscore?branch=master
+.. image:: https://coveralls.io/repos/github/xarray-contrib/xskillscore/badge.svg?branch=master
+   :target: https://coveralls.io/github/xarray-contrib/xskillscore?branch=master
 
 .. image:: https://img.shields.io/badge/benchmarked%20by-asv-green.svg?style=flat
    :target: https://raybellwaves.github.io/xskillscore/
@@ -39,7 +39,7 @@ You can also install the bleeding edge (pre-release versions) by running:
 
 .. code-block:: bash
 
-    pip install git+https://github.com/raybellwaves/xskillscore@master --upgrade
+    pip install git+https://github.com/xarray-contrib/xskillscore@master --upgrade
 
 **Getting Started**
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ AUTHOR = "Ray Bell"
 AUTHOR_EMAIL = "rayjohnbell0@gmail.com"
 DESCRIPTION = "xskillscore"
 LONG_DESCRIPTION = """Metrics for verifying forecasts"""
-URL = "https://github.com/raybellwaves/xskillscore"
+URL = "https://github.com/xarray-contrib/xskillscore"
 with open("requirements.txt") as f:
     INSTALL_REQUIRES = f.read().strip().split("\n")
 TESTS_REQUIRE = ["pytest"]

--- a/xskillscore/core/np_deterministic.py
+++ b/xskillscore/core/np_deterministic.py
@@ -38,7 +38,7 @@ def _match_nans(a, b, weights):
         # Find pairwise indices in a and b that have nans.
         idx = np.logical_or(np.isnan(a), np.isnan(b))
         a[idx], b[idx] = np.nan, np.nan
-        # https://github.com/raybellwaves/xskillscore/issues/168
+        # https://github.com/xarray-contrib/xskillscore/issues/168
         if isinstance(weights, np.ndarray):
             if weights.shape:  # not None
                 weights = weights.copy()

--- a/xskillscore/tests/test_skipna_functionality.py
+++ b/xskillscore/tests/test_skipna_functionality.py
@@ -85,7 +85,7 @@ def test_skipna_broadcast_weights_assignment_destination(
     a_nan, b_nan, weights_lonlat, metric
 ):
     """Tests that 'assignment destination is read-only' is not raised
-    https://github.com/raybellwaves/xskillscore/issues/79"""
+    https://github.com/xarray-contrib/xskillscore/issues/79"""
     metric(a_nan, b_nan, ["lat", "lon"], weights=weights_lonlat, skipna=True)
 
 


### PR DESCRIPTION
# Description

Updates references from old `raybellwaves` repo to `xarray-contrib`. 

Closes #(issue)

Forgot to install `pre-commit` on the new repo so might have some small errors from that.
