### PR TITLE
More GitHub actions updates

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Lint
 
-on: pull_request_target
+on: pull_request
 
 jobs:
   lint:  # Runs linting package checks for code styling.
@@ -14,19 +14,5 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.6
-      - name: Install linting dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install flake8 black isort
-      - name: Lint with flake8
-        shell: bash -l {0}
-        run: |
-          flake8 xskillscore
-      - name: Lint with black
-        shell: bash -l {0}
-        run: |
-          black --check xskillscore
-      - name: Lint with isort
-        shell: bash -l {0}
-        run: |
-          isort --check-only xskillscore
+      - name: Lint via pre-commit checks
+        uses: pre-commit/action@v2.0.0

--- a/.github/workflows/xskillscore_installs.yml
+++ b/.github/workflows/xskillscore_installs.yml
@@ -1,6 +1,6 @@
 name: xskillscore installs
 
-on: pull_request_target
+on: pull_request
 
 jobs:
   install-xskillscore:  # Installs xskillscore on various OS.

--- a/.github/workflows/xskillscore_testing.yml
+++ b/.github/workflows/xskillscore_testing.yml
@@ -6,7 +6,11 @@ jobs:
   test:  # Runs testing suite on various python versions.
     name: Test xskillscore, python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8]
     steps:
@@ -14,24 +18,24 @@ jobs:
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
-      - name: Install Conda environment
+      - name: Set up conda
         uses: conda-incubator/setup-miniconda@v1
         with:
           auto-update-conda: true
+          channels: conda-forge
+          mamba-version: '*'
           activate-environment: xskillscore-minimum-tests
-          environment-file: ci/minimum-tests.yml
           python-version: ${{ matrix.python-version }}
+      - name: Set up conda environment
+        run: |
+          mamba env update -f ci/minimum-tests.yml
       - name: Conda info
-        shell: bash -l {0}
         run: conda info
       - name: Conda list
-        shell: bash -l {0}
         run: conda list
       - name: Run tests
-        shell: bash -l {0}
         run: |
-          conda activate xskillscore-minimum-tests
-          pytest --cov=xskillscore --cov-report=xml
+          pytest --cov=xskillscore --cov-report=xml --verbose
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v1.0.7
         with:
@@ -41,28 +45,32 @@ jobs:
 
   docs_notebooks:  # Checks that pre-compiled notebooks in docs still work.
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
       - uses: actions/checkout@v2
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
-      - name: Install Conda environment
+      - name: Set up conda
         uses: conda-incubator/setup-miniconda@v1
         with:
           auto-update-conda: true
+          channels: conda-forge
+          mamba-version: '*'
           activate-environment: xskillscore-docs-notebooks
-          environment-file: ci/docs_notebooks.yml
           python-version: 3.6
+      - name: Set up conda environment
+        run: |
+          mamba env update -f ci/docs_notebooks.yml
       - name: Conda info
-        shell: bash -l {0}
         run: conda info
       - name: Conda list
-        shell: bash -l {0}
         run: conda list
       - name: Test notebooks in docs
-        shell: bash -l {0}
         run: |
           pushd docs
           nbstripout source/*.ipynb
-          make html
+          make -j4 html
           popd

--- a/.github/workflows/xskillscore_testing.yml
+++ b/.github/workflows/xskillscore_testing.yml
@@ -1,6 +1,6 @@
 name: xskillscore testing
 
-on: pull_request_target
+on: pull_request
 
 jobs:
   test:  # Runs testing suite on various python versions.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,8 +9,8 @@ repos:
       - id: check-merge-conflict
       - id: check-yaml
 
-  - repo: https://github.com/ambv/black
-    rev: 20.8b1
+  - repo: https://github.com/psf/black
+    rev: stable
     hooks:
     - id: black
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,28 +1,28 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.3
+    rev: v3.3.0
     hooks:
+      - id: trailing-whitespace
       - id: no-commit-to-branch
       - id: check-docstring-first
       - id: end-of-file-fixer
       - id: check-merge-conflict
+      - id: check-yaml
 
-  # isort should run before black as black sometimes tweaks the isort output
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.5.3
+  - repo: https://github.com/ambv/black
+    rev: 20.8b1
     hooks:
-      - id: isort
-
-  - repo: https://github.com/psf/black
-    rev: stable
-    hooks:
-      - id: black
+    - id: black
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.3
+    rev: 3.8.4
     hooks:
-      - id: flake8
-        args: ["--ignore=E203,E711,W503"]
+    - id: flake8
+
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.6.4
+    hooks:
+    - id: isort
 
   - repo: https://github.com/PyCQA/doc8
     rev: 0.8.1rc2

--- a/ci/dev.yml
+++ b/ci/dev.yml
@@ -25,7 +25,7 @@ dependencies:
   - xhistogram
   # Package Management
   - asv
-  - black==19.10b0
+  - black
   - coveralls
   - doc8
   - importlib_metadata

--- a/ci/minimum-tests.yml
+++ b/ci/minimum-tests.yml
@@ -1,7 +1,6 @@
 name: xskillscore-minimum-tests
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - bottleneck
   - cftime

--- a/docs/source/api/xskillscore.Contingency.rst
+++ b/docs/source/api/xskillscore.Contingency.rst
@@ -5,14 +5,14 @@
 
 .. autoclass:: Contingency
 
-   
+
    .. automethod:: __init__
 
-   
+
    .. rubric:: Methods
 
    .. autosummary::
-   
+
       ~Contingency.__init__
       ~Contingency.accuracy
       ~Contingency.bias_score
@@ -31,20 +31,18 @@
       ~Contingency.peirce_score
       ~Contingency.success_ratio
       ~Contingency.threat_score
-   
-   
 
-   
-   
+
+
+
+
    .. rubric:: Attributes
 
    .. autosummary::
-   
+
       ~Contingency.dichotomous
       ~Contingency.forecast_category_edges
       ~Contingency.forecasts
       ~Contingency.observation_category_edges
       ~Contingency.observations
       ~Contingency.table
-   
-   


### PR DESCRIPTION
# Description

Follows https://github.com/pangeo-data/climpred/pull/507.

* Uses `pre-commit` to lint. This ensures that the same linting environment is used on the dev side and in linting at the testing stage.
* Changes `pull_request_target` to `pull_request` so that updates to Github Actions are incorporated immediately on the PR.
* Updates `pre-commit` versions and releases version lock on `black`.