### PR TITLE
add nan corr tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,7 @@ Internal Changes
   (:issue:`160`, :pr:`230`) `Ray Bell`_
 - Pin ``numba`` to ``>=0.52`` to fix CI (:issue:`233`, :pr:`234`) `Ray Bell`_
 - Refactor ``asv`` benchmarks. (:pr:`231`) `Aaron Spring`_
+- Added tests for nans in correlation metrics (:issue:`246`, :pr:`XXX`) `Ray Bell`_
 
 
 xskillscore v0.0.18 (2020-09-23)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,7 +40,7 @@ Internal Changes
   (:issue:`160`, :pr:`230`) `Ray Bell`_
 - Pin ``numba`` to ``>=0.52`` to fix CI (:issue:`233`, :pr:`234`) `Ray Bell`_
 - Refactor ``asv`` benchmarks. (:pr:`231`) `Aaron Spring`_
-- Added tests for nans in correlation metrics (:issue:`246`, :pr:`XXX`) `Ray Bell`_
+- Added tests for nans in correlation metrics (:issue:`246`, :pr:`247`) `Ray Bell`_
 
 
 xskillscore v0.0.18 (2020-09-23)

--- a/xskillscore/tests/conftest.py
+++ b/xskillscore/tests/conftest.py
@@ -8,11 +8,28 @@ np.random.seed(42)
 
 
 @pytest.fixture
-def o():
+def times():
+    return xr.cftime_range(start="2000", periods=PERIODS, freq="D")
+
+
+@pytest.fixture
+def lats():
+    return np.arange(2)
+
+
+@pytest.fixture
+def lons():
+    return np.arange(3)
+
+
+@pytest.fixture
+def members():
+    return np.arange(4)
+
+
+@pytest.fixture
+def o(times, lats, lons):
     """Observation."""
-    times = xr.cftime_range(start="2000", periods=PERIODS, freq="D")
-    lats = np.arange(4)
-    lons = np.arange(5)
     data = np.random.rand(len(times), len(lats), len(lons))
     return xr.DataArray(
         data,
@@ -23,12 +40,8 @@ def o():
 
 
 @pytest.fixture
-def f_prob():
+def f_prob(times, lats, lons, members):
     """Probabilistic forecast containing also a member dimension."""
-    times = xr.cftime_range(start="2000", periods=PERIODS, freq="D")
-    members = np.arange(3)
-    lats = np.arange(4)
-    lons = np.arange(5)
     data = np.random.rand(len(members), len(times), len(lats), len(lons))
     return xr.DataArray(
         data,
@@ -84,7 +97,20 @@ def a_dask(a):
 
 @pytest.fixture
 def b_dask(b):
+    """Chunked"""
     return b.chunk()
+
+
+@pytest.fixture
+def a_dask_nan(a_nan):
+    """Chunked"""
+    return a_nan.chunk()
+
+
+@pytest.fixture
+def b_dask_nan(b_nan):
+    """Chunked"""
+    return b_nan.chunk()
 
 
 @pytest.fixture

--- a/xskillscore/tests/conftest.py
+++ b/xskillscore/tests/conftest.py
@@ -70,26 +70,26 @@ def b(f):
 
 # nan
 @pytest.fixture
-def a_nan(a):
+def a_rand_nan(a):
     """Masked"""
     return a.where(a < 0.5)
 
 
 @pytest.fixture
-def b_nan(b):
+def b_rand_nan(b):
     """Masked"""
     return b.where(b < 0.5)
 
 
 @pytest.fixture
-def a_nan_land(a):
+def a_fixed_nan(a):
     """Masked block"""
     a.data[:, 1:3, 1:3] = np.nan
     return a
 
 
 @pytest.fixture
-def b_nan_land(b):
+def b_fixed_nan(b):
     """Masked block"""
     b.data[:, 1:3, 1:3] = np.nan
     return b
@@ -116,15 +116,15 @@ def b_dask(b):
 
 
 @pytest.fixture
-def a_dask_nan(a_nan):
+def a_rand_nan_dask(a_rand_nan):
     """Chunked"""
-    return a_nan.chunk()
+    return a_rand_nan.chunk()
 
 
 @pytest.fixture
-def b_dask_nan(b_nan):
+def b_rand_nan_dask(b_rand_nan):
     """Chunked"""
-    return b_nan.chunk()
+    return b_rand_nan.chunk()
 
 
 @pytest.fixture

--- a/xskillscore/tests/conftest.py
+++ b/xskillscore/tests/conftest.py
@@ -14,17 +14,17 @@ def times():
 
 @pytest.fixture
 def lats():
-    return np.arange(2)
+    return np.arange(4)
 
 
 @pytest.fixture
 def lons():
-    return np.arange(3)
+    return np.arange(5)
 
 
 @pytest.fixture
 def members():
-    return np.arange(4)
+    return np.arange(3)
 
 
 @pytest.fixture
@@ -72,20 +72,34 @@ def b(f):
 @pytest.fixture
 def a_nan(a):
     """Masked"""
-    return a.copy().where(a < 0.5)
+    return a.where(a < 0.5)
 
 
 @pytest.fixture
 def b_nan(b):
     """Masked"""
-    return b.copy().where(b < 0.5)
+    return b.where(b < 0.5)
+
+
+@pytest.fixture
+def a_nan_land(a):
+    """Masked block"""
+    a.data[:, 1:3, 1:3] = np.nan
+    return a
+
+
+@pytest.fixture
+def b_nan_land(b):
+    """Masked block"""
+    b.data[:, 1:3, 1:3] = np.nan
+    return b
 
 
 # with zeros
 @pytest.fixture
 def a_with_zeros(a):
     """Zeros"""
-    return a.copy().where(a < 0.5, 0)
+    return a.where(a < 0.5, 0)
 
 
 # dask

--- a/xskillscore/tests/conftest.py
+++ b/xskillscore/tests/conftest.py
@@ -27,6 +27,7 @@ def members():
     return np.arange(3)
 
 
+# o vs. f in probabilistic
 @pytest.fixture
 def o(times, lats, lons):
     """Observation."""
@@ -57,7 +58,7 @@ def f(f_prob):
     return f_prob.isel(member=0, drop=True)
 
 
-# a vs. b in deterministic, o vs. f in probabilistic
+# a vs. b in deterministic
 @pytest.fixture
 def a(o):
     return o
@@ -151,14 +152,14 @@ def b_1d(b):
 
 
 @pytest.fixture
-def a_1d_nan():
+def a_1d_fixed_nan():
     time = xr.cftime_range("2000-01-01", "2000-01-03", freq="D")
     return xr.DataArray([3, np.nan, 5], dims=["time"], coords=[time])
 
 
 @pytest.fixture
-def b_1d_nan(a_1d_nan):
-    b = a_1d_nan.copy()
+def b_1d_fixed_nan(a_1d_fixed_nan):
+    b = a_1d_fixed_nan.copy()
     b.values = [7, 2, np.nan]
     return b
 
@@ -171,7 +172,7 @@ def a_1d_with_zeros(a_with_zeros):
 
 # weights
 @pytest.fixture
-def weights(a):
+def weights_cos_lat(a):
     """Weighting array by cosine of the latitude."""
     return xr.ones_like(a) * np.abs(np.cos(a.lat))
 
@@ -190,11 +191,11 @@ def weights_time():
 
 
 @pytest.fixture
-def weights_dask(weights):
+def weights_cos_lat_dask(weights_cos_lat):
     """
     Weighting array by cosine of the latitude.
     """
-    return weights.chunk()
+    return weights_cos_lat.chunk()
 
 
 @pytest.fixture

--- a/xskillscore/tests/test_accessor_deterministic.py
+++ b/xskillscore/tests/test_accessor_deterministic.py
@@ -78,14 +78,14 @@ def adjust_weights(dim, weight_bool, weights):
 @pytest.mark.parametrize("weight_bool", [False, True])
 @pytest.mark.parametrize("skipna_bool", [False, True])
 def test_deterministic_metrics_accessor(
-    a, b, dim, skipna_bool, weight_bool, weights, metric, outer_bool
+    a, b, dim, skipna_bool, weight_bool, weights_cos_lat, metric, outer_bool
 ):
 
     # Update dim to time if testing temporal only metrics
     if (dim != "time") and (metric in temporal_only_metrics):
         dim = "time"
 
-    _weights = adjust_weights(dim, weight_bool, weights)
+    _weights = adjust_weights(dim, weight_bool, weights_cos_lat)
     ds = _ds(a, b, skipna_bool)
     b = ds["b"]  # Update if populated with nans
     if outer_bool:

--- a/xskillscore/tests/test_deterministic.py
+++ b/xskillscore/tests/test_deterministic.py
@@ -141,7 +141,7 @@ def test_correlation_metrics_ufunc_same_np(
 @pytest.mark.parametrize("weight_bool", [True, False])
 @pytest.mark.parametrize("skipna", [True, False])
 @pytest.mark.parametrize("has_nan", [True, False])
-def test_correlation_metrics_ufunc_dask_same_da(
+def test_correlation_metrics_daskda_same_npda(
     a_dask, b_dask, dim, weight_bool, weights_dask, metrics, skipna, has_nan
 ):
     """Test whether correlation metric for xarray functions can be lazy when
@@ -218,7 +218,7 @@ def test_distance_metrics_ufunc_same_np(
 @pytest.mark.parametrize("weight_bool", [True, False])
 @pytest.mark.parametrize("skipna", [True, False])
 @pytest.mark.parametrize("has_nan", [True, False])
-def test_distance_metrics_ufunc_dask_same_da(
+def test_distance_metrics_daskda_same_npda(
     a_dask, b_dask, dim, weight_bool, weights_dask, metrics, skipna, has_nan
 ):
     """Test whether distance metric for xarray functions can be lazy when

--- a/xskillscore/tests/test_deterministic.py
+++ b/xskillscore/tests/test_deterministic.py
@@ -85,64 +85,16 @@ def adjust_weights(dim, weight_bool, weights):
 @pytest.mark.parametrize("metrics", correlation_metrics)
 @pytest.mark.parametrize("dim", AXES)
 @pytest.mark.parametrize("weight_bool", [True, False])
-def test_correlation_metrics_xr(a, b, dim, weight_bool, weights, metrics):
-    """Test whether correlation metric for xarray functions (from
-    deterministic.py) give save numerical results as for numpy functions (from
-    np_deterministic.py)."""
-    # unpack metrics
-    metric, _metric = metrics
-    # Only apply over time dimension for effective p value.
-    if (dim != "time") and (metric in temporal_only_metrics):
-        dim = "time"
-    # Generates subsetted weights to pass in as arg to main function and for
-    # the numpy testing.
-    _weights = adjust_weights(dim, weight_bool, weights)
-    # temporal only metrics have no weights argument
-    if metric in temporal_only_metrics:
-        actual = metric(a, b, dim)
-    else:
-        actual = metric(a, b, dim, weights=_weights)
-    # check that no chunks for no chunk inputs
-    assert actual.chunks is None
-
-    dim, _ = _preprocess_dims(dim, a)
-    if len(dim) > 1:
-        new_dim = "_".join(dim)
-        _a = a.stack(**{new_dim: dim})
-        _b = b.stack(**{new_dim: dim})
-        if weight_bool:
-            _weights = _weights.stack(**{new_dim: dim})
-    else:
-        new_dim = dim[0]
-        _a = a
-        _b = b
-    _weights = _preprocess_weights(_a, dim, new_dim, _weights)
-
-    # ensure _weights.values or None
-    _weights = None if _weights is None else _weights.values
-
-    axis = _a.dims.index(new_dim)
-    if metric in temporal_only_metrics:
-        res = _metric(_a.values, _b.values, axis, skipna=False)
-    else:
-        res = _metric(_a.values, _b.values, _weights, axis, skipna=False)
-    expected = actual.copy()
-    expected.values = res
-    assert_allclose(actual, expected)
-
-
-@pytest.mark.parametrize("metrics", correlation_metrics)
-@pytest.mark.parametrize("dim", AXES)
-@pytest.mark.parametrize("weight_bool", [True, False])
 @pytest.mark.parametrize("skipna", [True, False])
-def test_correlation_metrics_xr_nan(
-    a_nan, b_nan, dim, weight_bool, weights, metrics, skipna
+@pytest.mark.parametrize("has_nan", [True, False])
+def test_correlation_metrics_ufunc_same_np(
+    a, b, dim, weight_bool, weights, metrics, skipna, has_nan
 ):
     """Test whether correlation metric for xarray functions (from
     deterministic.py) give save numerical results as for numpy functions (from
-    np_deterministic.py) with nans."""
-    a = a_nan
-    b = b_nan
+    np_deterministic.py)."""
+    if has_nan:
+        a[0] = np.nan
     # unpack metrics
     metric, _metric = metrics
     # Only apply over time dimension for effective p value.
@@ -151,7 +103,6 @@ def test_correlation_metrics_xr_nan(
     # Generates subsetted weights to pass in as arg to main function and for
     # the numpy testing.
     _weights = adjust_weights(dim, weight_bool, weights)
-    #
     if metric in temporal_only_metrics:
         actual = metric(a, b, dim, skipna=skipna)
     else:
@@ -185,38 +136,44 @@ def test_correlation_metrics_xr_nan(
     assert_allclose(actual, expected)
 
 
-@pytest.mark.parametrize("metrics", distance_metrics)
+@pytest.mark.parametrize("metrics", correlation_metrics)
 @pytest.mark.parametrize("dim", AXES)
 @pytest.mark.parametrize("weight_bool", [True, False])
-def test_distance_metrics_xr(a, b, dim, weight_bool, weights, metrics):
-    """Test whether distance-based metric for xarray functions (from
-    deterministic.py) give save numerical results as for numpy functions from
-    np_deterministic.py)."""
+@pytest.mark.parametrize("skipna", [True, False])
+@pytest.mark.parametrize("has_nan", [True, False])
+def test_correlation_metrics_ufunc_dask_same_np(
+    a_dask, b_dask, dim, weight_bool, weights_dask, metrics, skipna, has_nan
+):
+    """Test whether correlation metric for xarray functions can be lazy when
+    chunked by using dask and give same results as np array."""
+    a = a_dask.copy()
+    b = b_dask.copy()
+    weights = weights_dask.copy()
+    if has_nan:
+        a = a.load()
+        a[0] = np.nan
+        a = a.chunk()
     # unpack metrics
     metric, _metric = metrics
+    # Only apply over time dimension for effective p value.
+    if (dim != "time") and (metric in temporal_only_metrics):
+        dim = "time"
     # Generates subsetted weights to pass in as arg to main function and for
     # the numpy testing.
-    weights = adjust_weights(dim, weight_bool, weights)
-    # median absolute error has no weights argument
-    if metric is median_absolute_error:
-        actual = metric(a, b, dim)
+    _weights = adjust_weights(dim, weight_bool, weights)
+    if metric in temporal_only_metrics:
+        actual = metric(a, b, dim, skipna=skipna)
     else:
-        actual = metric(a, b, dim, weights=weights)
-    assert actual.chunks is None
-
-    dim, axis = _preprocess_dims(dim, a)
-    _a = a
-    _b = b
-    _weights = _preprocess_weights(_a, dim, dim, weights)
-    axis = tuple(a.dims.index(d) for d in dim)
-    if metric is median_absolute_error:
-        res = _metric(_a.values, _b.values, axis, skipna=False)
+        actual = metric(a, b, dim, weights=_weights, skipna=skipna)
+    # check that chunks for chunk inputs
+    assert actual.chunks is not None
+    if _weights is not None:
+        _weights = _weights.load()
+    if metric in temporal_only_metrics:
+        expected = metric(a.load(), b.load(), dim, skipna=skipna)
     else:
-        # ensure _weights.values or None
-        _weights = None if _weights is None else _weights.values
-        res = _metric(_a.values, _b.values, _weights, axis, skipna=False)
-    expected = actual.copy()
-    expected.values = res
+        expected = metric(a.load(), b.load(), dim, _weights, skipna=skipna)
+    assert expected.chunks is None
     assert_allclose(actual, expected)
 
 
@@ -224,14 +181,15 @@ def test_distance_metrics_xr(a, b, dim, weight_bool, weights, metrics):
 @pytest.mark.parametrize("dim", AXES)
 @pytest.mark.parametrize("weight_bool", [True, False])
 @pytest.mark.parametrize("skipna", [True, False])
-def test_distance_metrics_xr_nan(
-    a_nan, b_nan, dim, weight_bool, weights, metrics, skipna
+@pytest.mark.parametrize("has_nan", [True, False])
+def test_distance_metrics_ufunc_same_np(
+    a, b, dim, weight_bool, weights, metrics, skipna, has_nan
 ):
     """Test whether distance-based metric for xarray functions (from
-    deterministic.py) give save numerical results as for numpy functions from
-    np_deterministic.py) with nans."""
-    a = a_nan
-    b = b_nan
+    deterministic.py) give save numerical results as for numpy functions (from
+    np_deterministic.py)."""
+    if has_nan:
+        a[0] = np.nan
     # unpack metrics
     metric, _metric = metrics
     # Generates subsetted weights to pass in as arg to main function and for
@@ -260,129 +218,23 @@ def test_distance_metrics_xr_nan(
     assert_allclose(actual, expected)
 
 
-@pytest.mark.parametrize("metrics", correlation_metrics)
-@pytest.mark.parametrize("dim", AXES)
-@pytest.mark.parametrize("weight_bool", [True, False])
-def test_correlation_metrics_xr_dask(
-    a_dask, b_dask, dim, weight_bool, weights_dask, metrics
-):
-    """Test whether correlation metric for xarray functions can be lazy when
-    chunked by using dask and give same results as np array."""
-    a = a_dask
-    b = b_dask
-    weights = weights_dask
-    # unpack metrics
-    metric, _metric = metrics
-    # Only apply over time dimension for effective p value.
-    if (dim != "time") and (metric in temporal_only_metrics):
-        dim = "time"
-    # Generates subsetted weights to pass in as arg to main function and for
-    # the numpy testing.
-    _weights = adjust_weights(dim, weight_bool, weights)
-
-    if metric in temporal_only_metrics:
-        actual = metric(a, b, dim)
-    else:
-        actual = metric(a, b, dim, weights=_weights)
-    # check that chunks for chunk inputs
-    assert actual.chunks is not None
-
-    if _weights is not None:
-        _weights = _weights.load()
-
-    if metric in temporal_only_metrics:
-        expected = metric(a.load(), b.load(), dim)
-    else:
-        expected = metric(a.load(), b.load(), dim, _weights)
-    assert expected.chunks is None
-    assert_allclose(actual.compute(), expected)
-
-
 @pytest.mark.parametrize("metrics", distance_metrics)
 @pytest.mark.parametrize("dim", AXES)
 @pytest.mark.parametrize("weight_bool", [True, False])
-def test_distance_metrics_xr_dask(
-    a_dask, b_dask, dim, weight_bool, weights_dask, metrics
+@pytest.mark.parametrize("skipna", [True, False])
+@pytest.mark.parametrize("has_nan", [True, False])
+def test_distance_metrics_ufunc_dask_same_np(
+    a_dask, b_dask, dim, weight_bool, weights_dask, metrics, skipna, has_nan
 ):
-    """Test whether distance metrics for xarray functions can be lazy when
+    """Test whether distance metric for xarray functions can be lazy when
     chunked by using dask and give same results as np array."""
     a = a_dask.copy()
     b = b_dask.copy()
     weights = weights_dask.copy()
-    # unpack metrics
-    metric, _metric = metrics
-    # Generates subsetted weights to pass in as arg to main function and for
-    # the numpy testing.
-    _weights = adjust_weights(dim, weight_bool, weights)
-    if _weights is not None:
-        _weights = _weights.load()
-    if metric is median_absolute_error:
-        actual = metric(a, b, dim)
-    else:
-        actual = metric(a, b, dim, weights=_weights)
-    # check that chunks for chunk inputs
-    assert actual.chunks is not None
-    if metric is median_absolute_error:
-        expected = metric(a.load(), b.load(), dim)
-    else:
-        expected = metric(a.load(), b.load(), dim, weights=_weights)
-    assert expected.chunks is None
-    assert_allclose(actual.compute(), expected)
-
-
-@pytest.mark.parametrize("metrics", correlation_metrics)
-@pytest.mark.parametrize("dim", AXES)
-@pytest.mark.parametrize("weight_bool", [True, False])
-@pytest.mark.parametrize("skipna", [True, False])
-@pytest.mark.parametrize("has_nan", [True])
-def test_correlation_metrics_xr_dask_nan(
-    a_dask_nan, b_dask_nan, dim, weight_bool, weights_dask, metrics, skipna, has_nan
-):
-    """Test whether correlation metric for xarray functions can be lazy when
-    chunked by using dask and give same results as np array with nans."""
-    a = a_dask_nan
-    b = b_dask_nan
-    weights = weights_dask
-    # unpack metrics
-    metric, _metric = metrics
-    # Only apply over time dimension for effective p value.
-    if (dim != "time") and (metric in temporal_only_metrics):
-        dim = "time"
-    # Generates subsetted weights to pass in as arg to main function and for
-    # the numpy testing.
-    _weights = adjust_weights(dim, weight_bool, weights)
-
-    if metric in temporal_only_metrics:
-        actual = metric(a, b, dim, skipna=skipna)
-    else:
-        actual = metric(a, b, dim, weights=_weights, skipna=skipna)
-    # check that chunks for chunk inputs
-    assert actual.chunks is not None
-
-    if _weights is not None:
-        _weights = _weights.load()
-
-    if metric in temporal_only_metrics:
-        expected = metric(a.load(), b.load(), dim, skipna=skipna)
-    else:
-        expected = metric(a.load(), b.load(), dim, _weights, skipna=skipna)
-    assert expected.chunks is None
-    assert_allclose(actual.compute(), expected)
-
-
-@pytest.mark.parametrize("metrics", distance_metrics)
-@pytest.mark.parametrize("dim", AXES)
-@pytest.mark.parametrize("weight_bool", [True, False])
-@pytest.mark.parametrize("skipna", [True, False])
-@pytest.mark.parametrize("has_nan", [True])
-def test_distance_metrics_xr_dask_nan(
-    a_dask_nan, b_dask_nan, dim, weight_bool, weights_dask, metrics, skipna, has_nan
-):
-    """Test whether distance metrics for xarray functions can be lazy when
-    chunked by using dask and give same results as np array with nans."""
-    a = a_dask_nan.copy()
-    b = b_dask_nan.copy()
-    weights = weights_dask.copy()
+    if has_nan:
+        a = a.load()
+        a[0] = np.nan
+        a = a.chunk()
     # unpack metrics
     metric, _metric = metrics
     # Generates subsetted weights to pass in as arg to main function and for
@@ -401,7 +253,7 @@ def test_distance_metrics_xr_dask_nan(
     else:
         expected = metric(a.load(), b.load(), dim, weights=_weights, skipna=skipna)
     assert expected.chunks is None
-    assert_allclose(actual.compute(), expected)
+    assert_allclose(actual, expected)
 
 
 @pytest.mark.parametrize("dim", AXES)

--- a/xskillscore/tests/test_deterministic.py
+++ b/xskillscore/tests/test_deterministic.py
@@ -88,7 +88,7 @@ def adjust_weights(dim, weight_bool, weights):
 @pytest.mark.parametrize("skipna", [True, False])
 @pytest.mark.parametrize("has_nan", [True, False])
 def test_correlation_metrics_ufunc_same_np(
-    a, b, dim, weight_bool, weights, metrics, skipna, has_nan
+    a, b, dim, weight_bool, weights_cos_lat, metrics, skipna, has_nan
 ):
     """Test whether correlation metric for xarray functions (from
     deterministic.py) give save numerical results as for numpy functions (from
@@ -102,7 +102,7 @@ def test_correlation_metrics_ufunc_same_np(
         dim = "time"
     # Generates subsetted weights to pass in as arg to main function and for
     # the numpy testing.
-    _weights = adjust_weights(dim, weight_bool, weights)
+    _weights = adjust_weights(dim, weight_bool, weights_cos_lat)
     if metric in temporal_only_metrics:
         actual = metric(a, b, dim, skipna=skipna)
     else:
@@ -142,13 +142,13 @@ def test_correlation_metrics_ufunc_same_np(
 @pytest.mark.parametrize("skipna", [True, False])
 @pytest.mark.parametrize("has_nan", [True, False])
 def test_correlation_metrics_daskda_same_npda(
-    a_dask, b_dask, dim, weight_bool, weights_dask, metrics, skipna, has_nan
+    a_dask, b_dask, dim, weight_bool, weights_cos_lat_dask, metrics, skipna, has_nan
 ):
     """Test whether correlation metric for xarray functions can be lazy when
     chunked by using dask and give same results as DataArray with numpy array."""
     a = a_dask.copy()
     b = b_dask.copy()
-    weights = weights_dask.copy()
+    weights = weights_cos_lat_dask.copy()
     metric, _ = metrics
     if has_nan:
         a = a.load()
@@ -178,7 +178,7 @@ def test_correlation_metrics_daskda_same_npda(
 @pytest.mark.parametrize("skipna", [True, False])
 @pytest.mark.parametrize("has_nan", [True, False])
 def test_distance_metrics_ufunc_same_np(
-    a, b, dim, weight_bool, weights, metrics, skipna, has_nan
+    a, b, dim, weight_bool, weights_cos_lat, metrics, skipna, has_nan
 ):
     """Test whether distance-based metric for xarray functions (from
     deterministic.py) give save numerical results as for numpy functions (from
@@ -189,7 +189,7 @@ def test_distance_metrics_ufunc_same_np(
     metric, _metric = metrics
     # Generates subsetted weights to pass in as arg to main function and for
     # the numpy testing.
-    weights = adjust_weights(dim, weight_bool, weights)
+    weights = adjust_weights(dim, weight_bool, weights_cos_lat)
     # median absolute error has no weights argument
     if metric is median_absolute_error:
         actual = metric(a, b, dim, skipna=skipna)
@@ -219,13 +219,13 @@ def test_distance_metrics_ufunc_same_np(
 @pytest.mark.parametrize("skipna", [True, False])
 @pytest.mark.parametrize("has_nan", [True, False])
 def test_distance_metrics_daskda_same_npda(
-    a_dask, b_dask, dim, weight_bool, weights_dask, metrics, skipna, has_nan
+    a_dask, b_dask, dim, weight_bool, weights_cos_lat_dask, metrics, skipna, has_nan
 ):
     """Test whether distance metric for xarray functions can be lazy when
     chunked by using dask and give same results as DataArray with numpy array."""
     a = a_dask.copy()
     b = b_dask.copy()
-    weights = weights_dask.copy()
+    weights = weights_cos_lat_dask.copy()
     metric, _ = metrics
     if has_nan:
         a = a.load()

--- a/xskillscore/tests/test_mask_skipna.py
+++ b/xskillscore/tests/test_mask_skipna.py
@@ -29,21 +29,15 @@ correlation_metrics = [
 ]
 
 
-def mask_land_data(da):
-    """Masks sample data arbitrarily like a block of land."""
-    da.data[:, 1:3, 1:3] = np.nan
-    return da
-
-
 @pytest.mark.parametrize("metric", correlation_metrics + distance_metrics)
 @pytest.mark.parametrize("dim", AXES)
-def test_metrics_masked(a, b, dim, metric):
+def test_metrics_masked(a_nan_land, b_nan_land, dim, metric):
     """Test for all distance-based metrics whether result of skipna does not
     contain any nans when applied along dim with nans."""
-    a_masked = mask_land_data(a)
-    b_masked = mask_land_data(b)
-    res_skipna = metric(a_masked, b_masked, dim, skipna=True)
-    res_no_skipna = metric(a_masked, b_masked, dim, skipna=False)
+    a = a_nan_land
+    b = b_nan_land
+    res_skipna = metric(a, b, dim, skipna=True)
+    res_no_skipna = metric(a, b, dim, skipna=False)
 
     if "lon" in dim or "lat" in dim:  # metric is applied along axis with nans
         # res_skipna shouldnt have nans

--- a/xskillscore/tests/test_mask_skipna.py
+++ b/xskillscore/tests/test_mask_skipna.py
@@ -31,11 +31,11 @@ correlation_metrics = [
 
 @pytest.mark.parametrize("metric", correlation_metrics + distance_metrics)
 @pytest.mark.parametrize("dim", AXES)
-def test_metrics_masked(a_nan_land, b_nan_land, dim, metric):
+def test_metrics_masked(a_fixed_nan, b_fixed_nan, dim, metric):
     """Test for all distance-based metrics whether result of skipna does not
     contain any nans when applied along dim with nans."""
-    a = a_nan_land
-    b = b_nan_land
+    a = a_fixed_nan
+    b = b_fixed_nan
     res_skipna = metric(a, b, dim, skipna=True)
     res_no_skipna = metric(a, b, dim, skipna=False)
 

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -59,9 +59,11 @@ def test_crps_ensemble_dim(o, f_prob, dim):
 
 
 @pytest.mark.parametrize("keep_attrs", [True, False])
-def test_crps_ensemble_weighted(o, f_prob, weights, keep_attrs):
+def test_crps_ensemble_weighted(o, f_prob, weights_cos_lat, keep_attrs):
     dim = ["lon", "lat"]
-    actual = crps_ensemble(o, f_prob, dim=dim, weights=weights, keep_attrs=keep_attrs)
+    actual = crps_ensemble(
+        o, f_prob, dim=dim, weights=weights_cos_lat, keep_attrs=keep_attrs
+    )
     assert_only_dim_reduced(dim, actual, o)
 
 

--- a/xskillscore/tests/test_skipna_functionality.py
+++ b/xskillscore/tests/test_skipna_functionality.py
@@ -75,28 +75,30 @@ def drop_nans(a, b, weights=None, dim="time"):
 
 
 @pytest.mark.parametrize("metric", WEIGHTED_METRICS + NON_WEIGHTED_METRICS)
-def test_skipna_returns_same_value_as_dropped_pairwise_nans(a_1d_nan, b_1d_nan, metric):
+def test_skipna_returns_same_value_as_dropped_pairwise_nans(
+    a_1d_fixed_nan, b_1d_fixed_nan, metric
+):
     """Tests that DataArrays with pairwise nans return the same result
     as the same two with those nans dropped."""
-    a_dropped, b_dropped, _ = drop_nans(a_1d_nan, b_1d_nan)
+    a_dropped, b_dropped, _ = drop_nans(a_1d_fixed_nan, b_1d_fixed_nan)
     with raise_if_dask_computes():
-        res_with_nans = metric(a_1d_nan, b_1d_nan, "time", skipna=True)
+        res_with_nans = metric(a_1d_fixed_nan, b_1d_fixed_nan, "time", skipna=True)
         res_dropped_nans = metric(a_dropped, b_dropped, "time")
     assert_allclose(res_with_nans, res_dropped_nans)
 
 
 @pytest.mark.parametrize("metric", WEIGHTED_METRICS)
 def test_skipna_returns_same_value_as_dropped_pairwise_nans_with_weights(
-    a_1d_nan, b_1d_nan, weights_time, metric
+    a_1d_fixed_nan, b_1d_fixed_nan, weights_time, metric
 ):
     """Tests that DataArrays with pairwise nans return the same result
     as the same two with those nans dropped."""
     a_dropped, b_dropped, weights_time_dropped = drop_nans(
-        a_1d_nan, b_1d_nan, weights_time
+        a_1d_fixed_nan, b_1d_fixed_nan, weights_time
     )
     with raise_if_dask_computes():
         res_with_nans = metric(
-            a_1d_nan, b_1d_nan, "time", skipna=True, weights=weights_time
+            a_1d_fixed_nan, b_1d_fixed_nan, "time", skipna=True, weights=weights_time
         )
         res_dropped_nans = metric(
             a_dropped, b_dropped, "time", weights=weights_time_dropped
@@ -105,11 +107,11 @@ def test_skipna_returns_same_value_as_dropped_pairwise_nans_with_weights(
 
 
 @pytest.mark.parametrize("metric", WEIGHTED_METRICS + NON_WEIGHTED_METRICS)
-def test_skipna_returns_nan_when_false(a_1d_nan, b_1d_nan, metric):
+def test_skipna_returns_nan_when_false(a_1d_fixed_nan, b_1d_fixed_nan, metric):
     """Tests that nan is returned if there's any nans in the time series
     and skipna is False."""
     with raise_if_dask_computes():
-        res = metric(a_1d_nan, b_1d_nan, "time", skipna=False)
+        res = metric(a_1d_fixed_nan, b_1d_fixed_nan, "time", skipna=False)
     assert np.isnan(res).all()
 
 

--- a/xskillscore/tests/test_skipna_functionality.py
+++ b/xskillscore/tests/test_skipna_functionality.py
@@ -115,12 +115,14 @@ def test_skipna_returns_nan_when_false(a_1d_nan, b_1d_nan, metric):
 
 @pytest.mark.parametrize("metric", WEIGHTED_METRICS)
 def test_skipna_broadcast_weights_assignment_destination(
-    a_nan, b_nan, weights_lonlat, metric
+    a_rand_nan, b_rand_nan, weights_lonlat, metric
 ):
     """Tests that 'assignment destination is read-only' is not raised
     https://github.com/xarray-contrib/xskillscore/issues/79"""
     with raise_if_dask_computes():
-        metric(a_nan, b_nan, ["lat", "lon"], weights=weights_lonlat, skipna=True)
+        metric(
+            a_rand_nan, b_rand_nan, ["lat", "lon"], weights=weights_lonlat, skipna=True
+        )
 
 
 def test_nan_skipna(a, b):


### PR DESCRIPTION
Closes #246

-   [x]  refactoring

Ignore the name of the branch. I worked on added nans to in the correlation tests.

I impact did a little bit of work on #245 but this doesn't close that.

I took out the `has_nan` parameter to the tests and instead moved to another test for nans which I could use `a_nan` from the conftest.py. Unfortunately it means duplicating most of the code in the test function but from reading some pytest docs they recommend using fixtures in the conftest.py as function imputs. Not sure if we create another function inside test_deterministic or even move some upstream to conftest.py to avoid the duplicated code.