### PR TITLE
Update xhistogram

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,7 +44,9 @@ Internal Changes
 - Refactor ``asv`` benchmarks. (:pr:`231`) `Aaron Spring`_
 - Added tests for nans in correlation metrics (:issue:`246`, :pr:`247`) `Ray Bell`_
 - Added tests for weighted metrics against scikit-learn (:pr:`257`) `Ray Bell`_
-
+- Pin ``xhistogram`` to ``>=0.1.2`` and adjust code/documentation so that 
+  right-most bin is right-edge inclusive where bins are specified 
+  (:pr:`269`) `Dougie Squire`_
 
 xskillscore v0.0.18 (2020-09-23)
 --------------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,8 +44,8 @@ Internal Changes
 - Refactor ``asv`` benchmarks. (:pr:`231`) `Aaron Spring`_
 - Added tests for nans in correlation metrics (:issue:`246`, :pr:`247`) `Ray Bell`_
 - Added tests for weighted metrics against scikit-learn (:pr:`257`) `Ray Bell`_
-- Pin ``xhistogram`` to ``>=0.1.2`` and adjust code/documentation so that
-  right-most bin is right-edge inclusive where bins are specified
+- Pin ``xhistogram`` to ``>=0.1.2`` and adjust code/documentation so that, as in
+  np.histogram, right-most bin is right-edge inclusive where bins are specified
   (:pr:`269`) `Dougie Squire`_
 
 xskillscore v0.0.18 (2020-09-23)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,8 +44,8 @@ Internal Changes
 - Refactor ``asv`` benchmarks. (:pr:`231`) `Aaron Spring`_
 - Added tests for nans in correlation metrics (:issue:`246`, :pr:`247`) `Ray Bell`_
 - Added tests for weighted metrics against scikit-learn (:pr:`257`) `Ray Bell`_
-- Pin ``xhistogram`` to ``>=0.1.2`` and adjust code/documentation so that 
-  right-most bin is right-edge inclusive where bins are specified 
+- Pin ``xhistogram`` to ``>=0.1.2`` and adjust code/documentation so that
+  right-most bin is right-edge inclusive where bins are specified
   (:pr:`269`) `Dougie Squire`_
 
 xskillscore v0.0.18 (2020-09-23)

--- a/ci/dev.yml
+++ b/ci/dev.yml
@@ -22,7 +22,7 @@ dependencies:
   - scikit-learn
   - scipy
   - xarray>=0.16.1
-  - xhistogram
+  - xhistogram>=0.1.2
   # Package Management
   - asv
   - black

--- a/ci/doc.yml
+++ b/ci/doc.yml
@@ -19,6 +19,6 @@ dependencies:
   - sphinx-autosummary-accessors
   - toolz
   - xarray>=0.16.1
-  - xhistogram
+  - xhistogram>=0.1.2
   - pip:
       - -e ..

--- a/ci/docs_notebooks.yml
+++ b/ci/docs_notebooks.yml
@@ -11,7 +11,7 @@ dependencies:
   - scikit-learn
   - scipy
   - xarray>=0.16.1
-  - xhistogram
+  - xhistogram>=0.1.2
   - importlib_metadata
   - jupyterlab
   - matplotlib

--- a/ci/minimum-tests.yml
+++ b/ci/minimum-tests.yml
@@ -11,7 +11,7 @@ dependencies:
   - scikit-learn
   - scipy
   - xarray>=0.16.1
-  - xhistogram
+  - xhistogram>=0.1.2
   - coveralls
   - pytest
   - pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ scikit-learn
 scipy
 toolz
 xarray>=0.16.1
-xhistogram
+xhistogram>=0.1.2

--- a/xskillscore/core/contingency.py
+++ b/xskillscore/core/contingency.py
@@ -13,10 +13,13 @@ FORECASTS_NAME = "forecasts"
 
 def _get_category_bounds(category_edges):
     """Return formatted string of category bounds given list of category edges"""
-    return [
+    bounds = [
         f"[{str(category_edges[i])}, {str(category_edges[i + 1])})"
-        for i in range(len(category_edges) - 1)
+        for i in range(len(category_edges) - 2)
     ]
+    # Last category is right edge inclusive
+    bounds.append(f"[{str(category_edges[-2])}, {str(category_edges[-1])}]")
+    return bounds
 
 
 def dichotomous_only(method):

--- a/xskillscore/core/contingency.py
+++ b/xskillscore/core/contingency.py
@@ -54,12 +54,12 @@ class Contingency:
     forecasts : xarray.Dataset or xarray.DataArray
         Labeled array(s) over which to apply the function.
     observation_category_edges : array_like
-        Bin edges for categorising observations.
-        All but the last (righthand-most) bin include the left edge and \
+        Bin edges for categorising observations. Similar to np.histogram, \
+        all but the last (righthand-most) bin include the left edge and \
         exclude the right edge. The last bin includes both edges.
     forecast_category_edges : array_like
-        Bin edges for categorising forecasts.
-        All but the last (righthand-most) bin include the left edge and \
+        Bin edges for categorising forecasts. Similar to np.histogram, \
+        all but the last (righthand-most) bin include the left edge and \
         exclude the right edge. The last bin includes both edges.
     dim : str, list
         The dimension(s) over which to compute the contingency table

--- a/xskillscore/core/contingency.py
+++ b/xskillscore/core/contingency.py
@@ -52,10 +52,12 @@ class Contingency:
         Labeled array(s) over which to apply the function.
     observation_category_edges : array_like
         Bin edges for categorising observations.
-        Bins include the left most edge, but not the right.
+        All but the last (righthand-most) bin include the left edge and \
+        exclude the right edge. The last bin includes both edges.
     forecast_category_edges : array_like
         Bin edges for categorising forecasts.
-        Bins include the left most edge, but not the right.
+        All but the last (righthand-most) bin include the left edge and \
+        exclude the right edge. The last bin includes both edges.
     dim : str, list
         The dimension(s) over which to compute the contingency table
 

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -461,8 +461,9 @@ def rps(
     forecasts : xarray.Dataset or xarray.DataArray
         The forecasts for the event.
     category_edges : array_like
-        Category bin edges used to compute the CDFs. Bins include the left most edge, \
-        but not the right.
+        Category bin edges used to compute the CDFs. All but the last \
+        (righthand-most) bin include the left edge and exclude the right \
+        edge. The last bin includes both edges.
     dim : str or list of str, optional
         Dimension over which to compute mean after computing ``rps``.
         Defaults to None implying averaging over all dimensions.
@@ -606,7 +607,7 @@ def discrimination(
     observations,
     forecasts,
     dim=None,
-    probability_bin_edges=np.linspace(0, 1 + 1e-8, 6),
+    probability_bin_edges=np.linspace(0, 1, 6),
 ):
     """Returns the data required to construct the discrimination diagram for an event;
        the histogram of forecasts likelihood when observations indicate an event has
@@ -625,8 +626,9 @@ def discrimination(
         Defaults to None meaning compute over all dimensions.
     probability_bin_edges : array_like, optional
         Probability bin edges used to compute the histograms.
-        Bins include the left most edge, \
-        but not the right. Defaults to 6 equally spaced edges between 0 and 1+1e-8
+        All but the last (righthand-most) bin include the left edge and \
+        exclude the right edge. The last bin includes both edges. Defaults \
+        to 6 equally spaced edges between 0 and 1
 
     Returns
     -------
@@ -695,7 +697,7 @@ def reliability(
     observations,
     forecasts,
     dim=None,
-    probability_bin_edges=np.linspace(0, 1 + 1e-8, 6),
+    probability_bin_edges=np.linspace(0, 1, 6),
     keep_attrs=False,
 ):
     """Returns the data required to construct the reliability diagram for an event;
@@ -715,8 +717,9 @@ def reliability(
             Defaults to None meaning compute over all dimensions.
         probability_bin_edges : array_like, optional
             Probability bin edges used to compute the reliability.
-            Bins include the left most edge, \
-            but not the right. Defaults to 6 equally spaced edges between 0 and 1+1e-8
+            All but the last (righthand-most) bin include the left edge and \
+            exclude the right edge. The last bin includes both edges. Defaults \
+            to 6 equally spaced edges between 0 and 1
         keep_attrs : bool, optional
             If True, the attributes (attrs) will be copied from the first input to
             the new one.
@@ -884,8 +887,9 @@ def roc(
         Labeled array(s) over which to apply the function.
         If ``bin_edges=='continuous'``, forecasts are probabilities.
     bin_edges : array_like, str, default='continuous'
-        Bin edges for categorising observations and forecasts.
-        Bins include the left most edge, but not the right. ``bin_edges`` will be
+        Bin edges for categorising observations and forecasts. All but the last \
+        (righthand-most) bin include the left edge and exclude the right \
+        edge. The last bin includes both edges. ``bin_edges`` will be
         sorted in ascending order. If ``bin_edges=='continuous'``, calculate
         ``bin_edges`` from forecasts, equal to
         ``sklearn.metrics.roc_curve(f_boolean, o_prob)``.

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -461,9 +461,9 @@ def rps(
     forecasts : xarray.Dataset or xarray.DataArray
         The forecasts for the event.
     category_edges : array_like
-        Category bin edges used to compute the CDFs. All but the last \
-        (righthand-most) bin include the left edge and exclude the right \
-        edge. The last bin includes both edges.
+        Category bin edges used to compute the CDFs. Similar to np.histogram, \
+        all but the last (righthand-most) bin include the left edge and exclude \
+        the right edge. The last bin includes both edges.
     dim : str or list of str, optional
         Dimension over which to compute mean after computing ``rps``.
         Defaults to None implying averaging over all dimensions.
@@ -625,10 +625,10 @@ def discrimination(
         Dimension(s) over which to compute the histograms
         Defaults to None meaning compute over all dimensions.
     probability_bin_edges : array_like, optional
-        Probability bin edges used to compute the histograms.
-        All but the last (righthand-most) bin include the left edge and \
-        exclude the right edge. The last bin includes both edges. Defaults \
-        to 6 equally spaced edges between 0 and 1
+        Probability bin edges used to compute the histograms. Similar to np.histogram, \
+        all but the last (righthand-most) bin include the left edge and exclude the \
+        right edge. The last bin includes both edges. Defaults to 6 equally spaced \
+        edges between 0 and 1
 
     Returns
     -------
@@ -716,10 +716,10 @@ def reliability(
             Dimension(s) over which to compute the histograms
             Defaults to None meaning compute over all dimensions.
         probability_bin_edges : array_like, optional
-            Probability bin edges used to compute the reliability.
-            All but the last (righthand-most) bin include the left edge and \
-            exclude the right edge. The last bin includes both edges. Defaults \
-            to 6 equally spaced edges between 0 and 1
+            Probability bin edges used to compute the reliability. Similar to np.histogram,
+            all but the last (righthand-most) bin include the left edge and exclude the \
+            right edge. The last bin includes both edges. Defaults to 6 equally spaced \
+            edges between 0 and 1
         keep_attrs : bool, optional
             If True, the attributes (attrs) will be copied from the first input to
             the new one.
@@ -772,9 +772,13 @@ def reliability(
             N = np.zeros_like(r)
 
         for i in range(len(bin_edges) - 1):
-            # Follow xhistogram: all bins are half-open
-            # https://github.com/xgcm/xhistogram/issues/18
-            f_in_bin = (f >= bin_edges[i]) & (f < bin_edges[i + 1])
+            # Follow xhistogram behaviour: all bins are half-open, except for the right-most bin
+            # which adds an epsilon to the right edge
+            # see https://github.com/xgcm/xhistogram/issues/18
+            if i == (len(bin_edges) - 2):
+                f_in_bin = (f >= bin_edges[i]) & (f < (bin_edges[i + 1] + 1e-8))
+            else:
+                f_in_bin = (f >= bin_edges[i]) & (f < bin_edges[i + 1])
             o_f_in_bin = o & f_in_bin
             N_f_in_bin = f_in_bin.sum(axis=-1)
             N_o_f_in_bin = o_f_in_bin.sum(axis=-1)
@@ -887,12 +891,11 @@ def roc(
         Labeled array(s) over which to apply the function.
         If ``bin_edges=='continuous'``, forecasts are probabilities.
     bin_edges : array_like, str, default='continuous'
-        Bin edges for categorising observations and forecasts. All but the last \
-        (righthand-most) bin include the left edge and exclude the right \
-        edge. The last bin includes both edges. ``bin_edges`` will be
-        sorted in ascending order. If ``bin_edges=='continuous'``, calculate
-        ``bin_edges`` from forecasts, equal to
-        ``sklearn.metrics.roc_curve(f_boolean, o_prob)``.
+        Bin edges for categorising observations and forecasts. Similar to np.histogram, \
+        all but the last (righthand-most) bin include the left edge and exclude the \
+        right edge. The last bin includes both edges. ``bin_edges`` will be sorted in \
+        ascending order. If ``bin_edges=='continuous'``, calculate ``bin_edges`` from \
+        forecasts, equal to ``sklearn.metrics.roc_curve(f_boolean, o_prob)``.
     dim : str, list
         The dimension(s) over which to compute the contingency table
     drop_intermediate : bool, default=False

--- a/xskillscore/tests/conftest.py
+++ b/xskillscore/tests/conftest.py
@@ -216,7 +216,7 @@ def weights_cos_lat_dask(weights_cos_lat):
 @pytest.fixture
 def category_edges():
     """Category bin edges between 0 and 1."""
-    return np.linspace(0, 1 + 1e-8, 6)
+    return np.linspace(0, 1, 6)
 
 
 @pytest.fixture

--- a/xskillscore/tests/test_accessor_probabilistic.py
+++ b/xskillscore/tests/test_accessor_probabilistic.py
@@ -140,7 +140,7 @@ def test_reliability_accessor(o, f_prob, threshold, outer_bool):
 
 @pytest.mark.parametrize("outer_bool", [False, True])
 def test_rps_accessor(o, f_prob, outer_bool):
-    category_edges = np.linspace(0, 1 + 1e-8, 6)
+    category_edges = np.linspace(0, 1, 6)
     actual = rps(o, f_prob, category_edges=category_edges)
 
     ds = xr.Dataset()
@@ -156,7 +156,7 @@ def test_rps_accessor(o, f_prob, outer_bool):
 
 @pytest.mark.parametrize("outer_bool", [False, True])
 def test_roc_accessor(o, f_prob, outer_bool):
-    bin_edges = np.linspace(0, 1 + 1e-8, 6)
+    bin_edges = np.linspace(0, 1, 6)
     actual = roc(o, f_prob, bin_edges=bin_edges)
 
     ds = xr.Dataset()

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -412,7 +412,11 @@ def test_reliability_values(o, f_prob):
         for lat in f_prob.lat:
             o_1d = o.sel(lon=lon, lat=lat) > 0.5
             f_1d = (f_prob.sel(lon=lon, lat=lat) > 0.5).mean("member")
-            actual = reliability(o_1d, f_1d)
+            # scipy bins are only left-edge inclusive and 1e-8 is added to the last bin, whereas
+            # xhistogram the rightmost edge of xhistogram bins is included - mimic scipy behaviour
+            actual = reliability(
+                o_1d, f_1d, probability_bin_edges=np.linspace(0, 1 + 1e-8, 6)
+            )
             expected, _ = calibration_curve(
                 o_1d, f_1d, normalize=False, n_bins=5, strategy="uniform"
             )
@@ -423,7 +427,13 @@ def test_reliability_values(o, f_prob):
 def test_reliability_perfect_values(o):
     """Test values for perfect forecast"""
     f_prob = xr.concat(10 * [o], dim="member")
-    actual = reliability(o > 0.5, (f_prob > 0.5).mean("member"))
+    # scipy bins are only left-edge inclusive and 1e-8 is added to the last bin, whereas
+    # xhistogram the rightmost edge of xhistogram bins is included - mimic scipy behaviour
+    actual = reliability(
+        o > 0.5,
+        (f_prob > 0.5).mean("member"),
+        probability_bin_edges=np.linspace(0, 1 + 1e-8, 6),
+    )
     expected_true_samples = (o > 0.5).sum()
     expected_false_samples = (o <= 0.5).sum()
     assert np.allclose(actual[0], 0)

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -427,12 +427,9 @@ def test_reliability_values(o, f_prob):
 def test_reliability_perfect_values(o):
     """Test values for perfect forecast"""
     f_prob = xr.concat(10 * [o], dim="member")
-    # scipy bins are only left-edge inclusive and 1e-8 is added to the last bin, whereas
-    # xhistogram the rightmost edge of xhistogram bins is included - mimic scipy behaviour
     actual = reliability(
         o > 0.5,
         (f_prob > 0.5).mean("member"),
-        probability_bin_edges=np.linspace(0, 1 + 1e-8, 6),
     )
     expected_true_samples = (o > 0.5).sum()
     expected_false_samples = (o <= 0.5).sum()


### PR DESCRIPTION
# Description

Updating to the latest version of xhistogram (0.1.2) which has a couple of new features that are useful to us:

- `density=True` now works

- consistent with np.histogram, the right-most bin is now right-edge-inclusive

I've removed all our hacks to include the right-edge of the right-most bin. I've also edited documentation and labelling to clearly and correctly describe how bins are defined. 

Closes #190

## Type of change

-   [x]  refactoring
