### PR TITLE
Avoid xhistogram=0.1.3

### DIFF
--- a/ci/dev.yml
+++ b/ci/dev.yml
@@ -22,7 +22,9 @@ dependencies:
   - scikit-learn
   - scipy
   - xarray>=0.16.1
-  - xhistogram>=0.1.2
+  # xhistogram 0.1.3 introduced an error that broke xskillscore
+  # see https://github.com/xgcm/xhistogram/issues/48
+  - xhistogram!=0.1.3
   # Package Management
   - asv
   - black

--- a/ci/doc.yml
+++ b/ci/doc.yml
@@ -19,6 +19,8 @@ dependencies:
   - sphinx-autosummary-accessors
   - toolz
   - xarray>=0.16.1
-  - xhistogram>=0.1.2
+  # xhistogram 0.1.3 introduced an error that broke xskillscore
+  # see https://github.com/xgcm/xhistogram/issues/48
+  - xhistogram!=0.1.3
   - pip:
       - -e ..

--- a/ci/docs_notebooks.yml
+++ b/ci/docs_notebooks.yml
@@ -12,7 +12,9 @@ dependencies:
   - scikit-learn
   - scipy
   - xarray>=0.16.1
-  - xhistogram>=0.1.2
+  # xhistogram 0.1.3 introduced an error that broke xskillscore
+  # see https://github.com/xgcm/xhistogram/issues/48
+  - xhistogram!=0.1.3
   - importlib_metadata
   - jupyterlab
   - matplotlib-base

--- a/ci/minimum-tests.yml
+++ b/ci/minimum-tests.yml
@@ -12,7 +12,9 @@ dependencies:
   - scikit-learn
   - scipy
   - xarray>=0.16.1
-  - xhistogram>=0.1.2
+  # xhistogram 0.1.3 introduced an error that broke xskillscore
+  # see https://github.com/xgcm/xhistogram/issues/48
+  - xhistogram!=0.1.3
   - coveralls
   - pytest
   - pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,6 @@ scikit-learn
 scipy
 toolz
 xarray>=0.16.1
-xhistogram>=0.1.2
+# xhistogram 0.1.3 introduced an error that broke xskillscore
+# see https://github.com/xgcm/xhistogram/issues/48
+xhistogram!=0.1.3


### PR DESCRIPTION
# Description

xhistogram=0.1.3 introduced an error that broke some functions in xskillscore (see https://github.com/xgcm/xhistogram/issues/48). This PR avoids this version of xhistogram.

Closes #288

## Type of change

-   [X]  Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

CI tests

## Checklist (while developing)

-   [X]  I have commented my code, particularly in hard-to-understand areas
