### PR TITLE
rps category_edges=None

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,10 @@ Internal Changes
 - :py:func:`~xskillscore.rps` does not break from masking NaNs anymore.
   :py:func:`~xskillscore.rps` expilicty checks for ``bin_dim`` if
   ``category_edges==None``. (:pr:`287`) `Aaron Spring`_
-
+- Specify category distribution type with ``category_dist`` in
+  :py:func:`~xskillscore.rps` if ``category_edges==None`` that forecasts and
+  observations are probability distribution functions ``pdf`` or cumulative
+  distribution functions ``cdf``. (:pr:`300`) `Aaron Spring`_
 
 xskillscore v0.0.19 (2021-03-12)
 --------------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,10 +12,11 @@ Internal Changes
 - :py:func:`~xskillscore.rps` does not break from masking NaNs anymore.
   :py:func:`~xskillscore.rps` expilicty checks for ``bin_dim`` if
   ``category_edges==None``. (:pr:`287`) `Aaron Spring`_
-- Specify category distribution type with ``category_dist`` in
+- Specify category distribution type with ``input_distributions`` in
   :py:func:`~xskillscore.rps` if ``category_edges==None`` that forecasts and
-  observations are probability distribution functions ``pdf`` or cumulative
-  distribution functions ``cdf``. (:pr:`300`) `Aaron Spring`_
+  observations are probability distributions ``p`` or cumulative
+  distributionss ``c``. See :py:func:`~xskillscore.rps` docstrings and doctests for
+  examples. (:pr:`300`) `Aaron Spring`_
 
 xskillscore v0.0.19 (2021-03-12)
 --------------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,9 @@ Internal Changes
 ~~~~~~~~~~~~~~~~
 - Use ``pytest-xdist`` and ``matplotlib-base`` in environments to speed up CI.
   (:pr:`283`) `Aaron Spring`_
+- :py:func:`~xskillscore.rps` does not break from masking NaNs anymore.
+  :py:func:`~xskillscore.rps` expilicty checks for ``bin_dim`` if
+  ``category_edges==None``. (:pr:`287`) `Aaron Spring`_
 
 
 xskillscore v0.0.19 (2021-03-12)

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -655,7 +655,12 @@ def rps(
         if fair:
             M = forecasts[member_dim].size
     elif category_edges is None and fair:
-        raise ValueError("category_edges=None and fair=True does not work.")
+        if member_dim in forecasts.coords and member_dim not in forecasts.dims:
+            M = forecasts[member_dim].astype("int")
+        else:
+            raise ValueError(
+                "category_edges=None and fair=True only works if forecast[member_dim] is a number in forecasts.coords."
+            )
 
     forecasts = _bool_to_int(forecasts)
 

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -625,7 +625,7 @@ def rps(
 
     """
     bin_dim = "category_edge"
-    if member_dim not in forecasts.dims:
+    if member_dim not in forecasts.dims and category_edges is not None:
         raise ValueError(
             f"Expect to find {member_dim} in forecasts dimensions, found"
             f"{forecasts.dims}."
@@ -681,6 +681,14 @@ def rps(
         Oc = (observations < observations_edges).astype("int")
 
     elif category_edges is None:  # expect CDFs already as inputs
+        if bin_dim not in forecasts.dims:
+            raise ValueError(
+                "Expected dimension {bin_dim} in forecasts, found {forecasts.dims}"
+            )
+        if bin_dim not in observations.dims:
+            raise ValueError(
+                "Expected dimension {bin_dim} in observations, found {observations.dims}"
+            )
         if member_dim in forecasts.dims:
             forecasts = forecasts.mean(member_dim)
         Fc = forecasts
@@ -707,7 +715,10 @@ def rps(
     # combine many forecasts-observations pairs
     res = res.mean(dim)
     # keep nans and prevent 0 for all nan grids
-    res = _keep_nans_masked(observations, res, dim, ignore=["category_edge"])
+    try:
+        res = _keep_nans_masked(observations, res, dim, ignore=["category_edge"])
+    except Exception as e:
+        print(f"could not mask all NaNs properly due to {type(e).__name__}: {e}")
     if keep_attrs:  # attach by hand
         res.attrs.update(observations.attrs)
         res.attrs.update(forecasts.attrs)

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -626,7 +626,7 @@ def rps(
 
     """
     bin_dim = "category_edge"
-    if member_dim not in forecasts.dims and category_edges is not None:
+    if member_dim not in forecasts.dims and category_edges != None:
         raise ValueError(
             f"Expect to find {member_dim} in forecasts dimensions, found"
             f"{forecasts.dims}."

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -699,7 +699,9 @@ def rps(
         Fc = forecasts.rename({category_dim: bin_dim})
         Oc = observations.rename({category_dim: bin_dim})
         assert bin_dim in Fc.dims, print(f"found {Fc.dims}")
+        assert category_dim not in Fc.dims, print(f"found {Fc.dims}")
         assert bin_dim in Oc.dims, print(f"found {Oc.dims}")
+        assert category_dim not in Oc.dims, print(f"found {Oc.dims}")
     else:
         raise ValueError(
             "category_edges must be xr.DataArray, xr.Dataset, tuple of xr.objects, "
@@ -708,7 +710,7 @@ def rps(
 
     # RPS formulas
     if fair:  # for ensemble member adjustment, see Ferro 2013
-        Ec = Fc * M
+        Ec = Fc * M  # maybe try to get M even for category_edges=None as coordinate
         res = ((Ec / M - Oc) ** 2 - Ec * (M - Ec) / (M ** 2 * (M - 1))).sum(bin_dim)
     else:  # normal formula
         res = ((Fc - Oc) ** 2).sum(bin_dim)

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -695,8 +695,8 @@ def rps(
             forecasts = forecasts.mean(member_dim)
         Fc = forecasts.rename({category_dim: bin_dim})
         Oc = observations.rename({category_dim: bin_dim})
-        assert category_dim in Fc.dims, print(f"found {Fc.dims}")
-        assert category_dim in Oc.dims, print(f"found {Oc.dims}")
+        assert bin_dim in Fc.dims, print(f"found {Fc.dims}")
+        assert bin_dim in Oc.dims, print(f"found {Oc.dims}")
     else:
         raise ValueError(
             "category_edges must be xr.DataArray, xr.Dataset, tuple of xr.objects, "

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -567,7 +567,9 @@ def rps(
         over multiple forecasts-observations pairs. Defaults to None implying averaging
         over all dimensions.
     fair: boolean
-        Apply ensemble member-size adjustment for unbiased, fair metric; see Ferro (2013).
+        Apply ensemble member-size adjustment for unbiased, fair metric; see Ferro
+        (2013). If ``fair==True`` and ``category_edges==None``, require forecasts to
+        have number of members in coordinates as forecasts[member_dim].
     weights : xr.DataArray with dimensions from dim, optional
         Weights for `weighted.mean(dim)`. Defaults to None, such that no weighting is
         applied.

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -695,6 +695,8 @@ def rps(
             forecasts = forecasts.mean(member_dim)
         Fc = forecasts.rename({category_dim: bin_dim})
         Oc = observations.rename({category_dim: bin_dim})
+        assert category_dim in Fc.dims, print(f"found {Fc.dims}")
+        assert category_dim in Oc.dims, print(f"found {Oc.dims}")
     else:
         raise ValueError(
             "category_edges must be xr.DataArray, xr.Dataset, tuple of xr.objects, "
@@ -716,7 +718,7 @@ def rps(
         res = res.weighted(weights)
     # combine many forecasts-observations pairs
     res = res.mean(dim)
-    # keep nans and prevent 0 for all nan grids
+    # keep nans and prevent 0 for all nan grids, could prevent this with skipna=False
     try:
         res = _keep_nans_masked(observations, res, dim, ignore=["category_edge"])
     except Exception as e:

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -590,6 +590,8 @@ def rps(
 
     Examples
     --------
+    >>> import xskillscore as xs
+    >>> np.random.seed(42)
     >>> observations = xr.DataArray(np.random.random(size=(3, 3)),
     ...                             coords=[('x', np.arange(3)),
     ...                                     ('y', np.arange(3))])
@@ -600,11 +602,11 @@ def rps(
     >>> category_edges = np.array([.33, .66])
     >>> xs.rps(observations, forecasts, category_edges, dim='x')
     <xarray.DataArray (y: 3)>
-    array([0.14814815, 0.7037037 , 1.51851852])
+    array([0.37037037, 0.81481481, 1.        ])
     Coordinates:
       * y                           (y) int64 0 1 2
-        forecasts_category_edge     <U38 '[-np.inf, 0.33), [0.33, 0.66), [0.66, np.inf]'
-        observations_category_edge  <U38 '[-np.inf, 0.33), [0.33, 0.66), [0.66, np.inf]'
+        observations_category_edge  <U45 '[-np.inf, 0.33), [0.33, 0.66), [0.66, n...
+        forecasts_category_edge     <U45 '[-np.inf, 0.33), [0.33, 0.66), [0.66, n...
 
 
     You can also define multi-dimensional ``category_edges``, e.g. with xr.quantile.
@@ -612,14 +614,26 @@ def rps(
     and observations distributions.
 
     >>> category_edges = observations.quantile(
-    ...     q=[.33, .66]).rename({'quantile': 'category_edge'}),
+    ...     q=[.33, .66]).rename({'quantile': 'category_edge'})
     >>> xs.rps(observations, forecasts, category_edges, dim='x')
     <xarray.DataArray (y: 3)>
-    array([1.18518519, 0.85185185, 0.40740741])
+    array([0.37037037, 0.81481481, 0.88888889])
     Coordinates:
       * y                           (y) int64 0 1 2
-        forecasts_category_edge     <U38 '[-np.inf, 0.33), [0.33, 0.66), [0.66, np.inf]'
-        observations_category_edge  <U38 '[-np.inf, 0.33), [0.33, 0.66), [0.66, np.inf]'
+        observations_category_edge  <U45 '[-np.inf, 0.33), [0.33, 0.66), [0.66, n...
+        forecasts_category_edge     <U45 '[-np.inf, 0.33), [0.33, 0.66), [0.66, n...
+
+    You can also provide cumulative (probability) distribution functions as inputs
+    without specifying ``category_edges`` but ``category_dist``:
+
+    >>> category_edges = category_edges.rename({'category_edge': 'category'})
+    >>> observations = observations < category_edges
+    >>> forecasts = (forecasts < category_edges).mean('member') # not exactly probabilities here
+    >>> xs.rps(observations, forecasts, category_edges=None, dim='x', category_dist='cdf')
+    <xarray.DataArray (y: 3)>
+    array([0.37037037, 0.81481481, 0.88888889])
+    Coordinates:
+      * y        (y) int64 0 1 2
 
     References
     ----------

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -597,7 +597,7 @@ def rps(
     Examples
     --------
     In the examples below `o` is used for observations and `f` for forecasts.
-    
+
     >>> import numpy as np
     >>> import xarray as xr
     >>> import xskillscore as xs

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -698,10 +698,7 @@ def rps(
             forecasts = forecasts.mean(member_dim)
         Fc = forecasts.rename({category_dim: bin_dim})
         Oc = observations.rename({category_dim: bin_dim})
-        assert bin_dim in Fc.dims, print(f"found {Fc.dims}")
-        assert category_dim not in Fc.dims, print(f"found {Fc.dims}")
-        assert bin_dim in Oc.dims, print(f"found {Oc.dims}")
-        assert category_dim not in Oc.dims, print(f"found {Oc.dims}")
+
     else:
         raise ValueError(
             "category_edges must be xr.DataArray, xr.Dataset, tuple of xr.objects, "
@@ -714,7 +711,6 @@ def rps(
         res = ((Ec / M - Oc) ** 2 - Ec * (M - Ec) / (M ** 2 * (M - 1))).sum(bin_dim)
     else:  # normal formula
         res = ((Fc - Oc) ** 2).sum(bin_dim)
-    assert bin_dim not in res.dims
 
     # add category_edge as str into coords
     if category_edges is not None:
@@ -729,7 +725,6 @@ def rps(
         res = _keep_nans_masked(observations, res, dim, ignore=["category_edge"])
     except Exception as e:
         print(f"could not mask all NaNs properly due to {type(e).__name__}: {e}")
-    assert bin_dim not in res.dims
     if keep_attrs:  # attach by hand
         res.attrs.update(observations.attrs)
         res.attrs.update(forecasts.attrs)

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -634,7 +634,7 @@ def rps(
 
     If you have probabilistic forecasts, i.e. without a ``member`` dimension but
     different ``category`` probabilities, you can also provide probability
-    distribution inputs by specifying ``category_edges=None`` but
+    distribution inputs by specifying ``category_edges=None`` and
     ``input_distributions``:
 
     >>> category_edges = category_edges.rename({'category_edge': 'category'})

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -699,7 +699,8 @@ def rps(
             M = forecasts[member_dim].astype("int")
         else:
             raise ValueError(
-                "category_edges=None and fair=True only works if forecast[member_dim] is a number in forecasts.coords."
+                "category_edges=None and fair=True only works "
+                "if forecast[member_dim] is a number in forecasts.coords."
             )
 
     forecasts = _bool_to_int(forecasts)
@@ -760,11 +761,13 @@ def rps(
         category_dim = "category"
         if category_dim not in forecasts.dims:
             raise ValueError(
-                f"Expected dimension {category_dim} in cumulative forecasts, found {forecasts.dims}"
+                f"Expected dimension {category_dim} in cumulative forecasts, "
+                f"found {forecasts.dims}"
             )
         if category_dim not in observations.dims:
             raise ValueError(
-                f"Expected dimension {category_dim} in cumulative observations, found {observations.dims}"
+                f"Expected dimension {category_dim} in cumulative observations, "
+                f"found {observations.dims}"
             )
 
         if member_dim in forecasts.dims:

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -558,7 +558,7 @@ def rps(
         - None: expect than observations and forecasts are already CDFs containing
           ``category`` dimension. Use this if your category edges vary across
           dimensions of forecasts and observations, and are different for each and
-          already cumulatively pre-computed.
+          already cumulatively pre-computed. Requires fair==False.
 
     dim : str or list of str, optional
         Dimension over which to mean after computing ``rps``. This represents a mean
@@ -634,6 +634,8 @@ def rps(
             )
         if fair:
             M = forecasts[member_dim].size
+    elif category_edges is None and fair:
+        raise ValueError("category_edges=None and fair=True does not work.")
 
     forecasts = _bool_to_int(forecasts)
 

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -626,13 +626,14 @@ def rps(
 
     """
     bin_dim = "category_edge"
-    if member_dim not in forecasts.dims and category_edges != None:
-        raise ValueError(
-            f"Expect to find {member_dim} in forecasts dimensions, found"
-            f"{forecasts.dims}."
-        )
-    if fair:
-        M = forecasts[member_dim].size
+    if category_edges is not None:
+        if member_dim not in forecasts.dims:
+            raise ValueError(
+                f"Expect to find {member_dim} in forecasts dimensions, found"
+                f"{forecasts.dims}."
+            )
+        if fair:
+            M = forecasts[member_dim].size
 
     forecasts = _bool_to_int(forecasts)
 

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -685,11 +685,11 @@ def rps(
         category_dim = "category"
         if category_dim not in forecasts.dims:
             raise ValueError(
-                "Expected dimension {category_dim} in cumulative forecasts, found {forecasts.dims}"
+                f"Expected dimension {category_dim} in cumulative forecasts, found {forecasts.dims}"
             )
         if bin_dim not in observations.dims:
             raise ValueError(
-                "Expected dimension {category_dim} in cumulative observations, found {observations.dims}"
+                f"Expected dimension {category_dim} in cumulative observations, found {observations.dims}"
             )
         if member_dim in forecasts.dims:
             forecasts = forecasts.mean(member_dim)

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -556,8 +556,9 @@ def rps(
           across dimensions of forecasts and observations, and are different for each.
 
         - None: expect than observations and forecasts are already CDFs containing
-          ``category_edge`` dimension. Use this if your category edges vary across
-          dimensions of forecasts and observations, and are different for each.
+          ``category`` dimension. Use this if your category edges vary across
+          dimensions of forecasts and observations, and are different for each and
+          already cumulatively pre-computed.
 
     dim : str or list of str, optional
         Dimension over which to mean after computing ``rps``. This represents a mean
@@ -681,18 +682,19 @@ def rps(
         Oc = (observations < observations_edges).astype("int")
 
     elif category_edges is None:  # expect CDFs already as inputs
-        if bin_dim not in forecasts.dims:
+        category_dim = "category"
+        if category_dim not in forecasts.dims:
             raise ValueError(
-                "Expected dimension {bin_dim} in forecasts, found {forecasts.dims}"
+                "Expected dimension {category_dim} in cumulative forecasts, found {forecasts.dims}"
             )
         if bin_dim not in observations.dims:
             raise ValueError(
-                "Expected dimension {bin_dim} in observations, found {observations.dims}"
+                "Expected dimension {category_dim} in cumulative observations, found {observations.dims}"
             )
         if member_dim in forecasts.dims:
             forecasts = forecasts.mean(member_dim)
-        Fc = forecasts
-        Oc = observations
+        Fc = forecasts.rename({category_dim: bin_dim})
+        Oc = observations.rename({category_dim: bin_dim})
     else:
         raise ValueError(
             "category_edges must be xr.DataArray, xr.Dataset, tuple of xr.objects, "

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -714,6 +714,7 @@ def rps(
         res = ((Ec / M - Oc) ** 2 - Ec * (M - Ec) / (M ** 2 * (M - 1))).sum(bin_dim)
     else:  # normal formula
         res = ((Fc - Oc) ** 2).sum(bin_dim)
+    assert bin_dim not in res.dims
 
     # add category_edge as str into coords
     if category_edges is not None:
@@ -728,6 +729,7 @@ def rps(
         res = _keep_nans_masked(observations, res, dim, ignore=["category_edge"])
     except Exception as e:
         print(f"could not mask all NaNs properly due to {type(e).__name__}: {e}")
+    assert bin_dim not in res.dims
     if keep_attrs:  # attach by hand
         res.attrs.update(observations.attrs)
         res.attrs.update(forecasts.attrs)

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -629,34 +629,47 @@ def rps(
         observations_category_edge  <U45 '[-np.inf, 0.33), [0.33, 0.66), [0.66, n...
         forecasts_category_edge     <U45 '[-np.inf, 0.33), [0.33, 0.66), [0.66, n...
 
-    If you have probabilistic forecasts, i.e. without a ``member`` dimension but different ``category`` probabilities, you can also provide ``p``robability distribution inputs
-    by specifying ``category_edges=None`` but ``input_distributions``:
+    If you have probabilistic forecasts, i.e. without a ``member`` dimension but
+    different ``category`` probabilities, you can also provide probability
+    distribution inputs by specifying ``category_edges=None`` but
+    ``input_distributions``:
 
     >>> category_edges = category_edges.rename({'category_edge': 'category'})
     >>> observations_p = xr.concat([
-    ...     (observations < category_edges.isel(category=0)).assign_coords(category='below normal'),
-    ...     ((observations >= category_edges.isel(category=0)) & (observations < category_edges.isel(category=1))).assign_coords(category='normal'),
-    ...     (observations >= category_edges.isel(category=1)).assign_coords(category='above normal')
+    ...     (observations < category_edges.isel(category=0)
+    ...         ).assign_coords(category='below normal'),
+    ...     ((observations >= category_edges.isel(category=0)) & (
+    ...         observations < category_edges.isel(category=1))
+    ...         ).assign_coords(category='normal'),
+    ...     (observations >= category_edges.isel(category=1)
+    ...         ).assign_coords(category='above normal')
     ... ], 'category')
     >>> #print(observations_p.sum('category'))
     >>> assert (observations_p.sum('category')==1).all()
     >>> forecasts_p = xr.concat([
-    ...     (forecasts < category_edges.isel(category=0)).assign_coords(category='below normal'),
-    ...     ((forecasts >= category_edges.isel(category=0)) & (forecasts < category_edges.isel(category=1))).assign_coords(category='normal'),
-    ...     (forecasts >= category_edges.isel(category=1)).assign_coords(category='above normal')
+    ...     (forecasts < category_edges.isel(category=0)
+    ...         ).assign_coords(category='below normal'),
+    ...     ((forecasts >= category_edges.isel(category=0)
+    ...         ) & (forecasts < category_edges.isel(category=1))
+    ...         ).assign_coords(category='normal'),
+    ...     (forecasts >= category_edges.isel(category=1)
+    ...         ).assign_coords(category='above normal')
     ... ], 'category').mean('member')
     >>> assert (forecasts_p.sum('category')==1).all()
-    >>> xs.rps(observations_p, forecasts_p, category_edges=None, dim='x', input_distributions='p')
+    >>> xs.rps(observations_p, forecasts_p, category_edges=None, dim='x',
+    ...     input_distributions='p')
     <xarray.DataArray (y: 3)>
     array([0.37037037, 0.81481481, 0.88888889])
     Coordinates:
       * y        (y) int64 0 1 2
 
-    Providing ``c``umulative distribution inputs yields identical results, where highest category equals 1 by default and can be ignored:
+    Providing cumulative distribution inputs yields identical results, where highest
+    category equals 1 by default and can be ignored:
 
     >>> observations_c = observations < category_edges
     >>> forecasts_c = (forecasts < category_edges).mean('member')
-    >>> xs.rps(observations_c, forecasts_c, category_edges=None, dim='x', input_distributions='c')
+    >>> xs.rps(observations_c, forecasts_c, category_edges=None, dim='x',
+    ...     input_distributions='c')
     <xarray.DataArray (y: 3)>
     array([0.37037037, 0.81481481, 0.88888889])
     Coordinates:

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -687,7 +687,7 @@ def rps(
             raise ValueError(
                 f"Expected dimension {category_dim} in cumulative forecasts, found {forecasts.dims}"
             )
-        if bin_dim not in observations.dims:
+        if category_dim not in observations.dims:
             raise ValueError(
                 f"Expected dimension {category_dim} in cumulative observations, found {observations.dims}"
             )

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -540,9 +540,9 @@ def rps(
         right side. Thus, N category edges produces N+1 bins. For example, specifying
         category_edges = [0,1] will compute the RPS for bins [-inf, 0), [0, 1) and
         [1, inf), which results in CDF bins [-inf, 0), [-inf, 1) and [-inf, inf).
-        Note that the edges are right-edge exclusive.
-        Forecasts, observations and category_edge are expected
-        in absolute units or probabilities consistently.
+        Note that the edges are right-edge exclusive. Forecasts, observations and
+        category_edge are expected in absolute units or probabilities consistently.
+        dtypes are handled accordingly:
 
         - np.array (1d): will be internally converted and broadcasted to observations.
           Use this if you wish to use the same category edges for all elements of both

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -730,10 +730,10 @@ def test_rps_category_edges_None(o, f_prob, fair_bool):
     bin_dim = "category"
     edges = xr.DataArray(e, dims=bin_dim, coords={bin_dim: e})
     o_c = o < edges  # CDF
-    f_prob_c = (f_prob < edges).mean("member")  # CDF
+    f_c = (f_prob < edges).mean("member")  # CDF
     print(o_c)
-    print(f_prob_c)
-    actual = rps(o_c, f_prob_c, dim="time", fair=fair_bool, category_edges=None)
+    print(f_c)
+    actual = rps(o_c, f_c, dim="time", fair=fair_bool, category_edges=None)
     print(actual)
     assert set(["lon", "lat"]) == set(actual.dims)
     assert "quantile" not in actual.dims

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -475,7 +475,7 @@ def test_rps_category_edges_None_fails(o, f_prob):
 
 def test_rps_category_edges_None_works(o, f_prob):
     """Test that rps expects inputs to have category_edges dim if category_edges is None."""
-    o = o.rename({"time": "category_edge"})
+    o = o.rename({"time": "category"})
     f_prob = f_prob.rename({"time": "category"}).mean("member")
     rps(o, f_prob, category_edges=None, dim=[])
 

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -470,7 +470,7 @@ def test_rps_reduce_dim(o, f_prob, category_edges, dim, fair_bool):
 def test_rps_category_edges_None_fails(o, f_prob):
     """Test that rps expects inputs to have category_edges dim if category_edges is None."""
     with pytest.raises(ValueError, match="Expected dimension"):
-        rps(o, f_prob, category_edges=None, dim=[], input_distributions="cdf")
+        rps(o, f_prob, category_edges=None, dim=[], input_distributions="c")
 
 
 @pytest.mark.parametrize("input_distributions", ["c", "p"])

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -730,10 +730,11 @@ def test_rps_category_edges_None(o, f_prob, fair_bool):
     bin_dim = "category"
     edges = xr.DataArray(e, dims=bin_dim, coords={bin_dim: e})
     o_c = o < edges  # CDF
-    f_prob_c = f_prob < edges  # CDF
+    f_prob_c = (f_prob < edges).mean("member")  # CDF
     print(o_c)
     print(f_prob_c)
     actual = rps(o_c, f_prob_c, dim="time", fair=fair_bool, category_edges=None)
+    print(actual)
     assert set(["lon", "lat"]) == set(actual.dims)
     assert "quantile" not in actual.dims
     assert "member" not in actual.dims

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -470,15 +470,15 @@ def test_rps_reduce_dim(o, f_prob, category_edges, dim, fair_bool):
 def test_rps_category_edges_None_fails(o, f_prob):
     """Test that rps expects inputs to have category_edges dim if category_edges is None."""
     with pytest.raises(ValueError, match="Expected dimension"):
-        rps(o, f_prob, category_edges=None, dim=[], category_dist="cdf")
+        rps(o, f_prob, category_edges=None, dim=[], input_distributions="cdf")
 
 
-@pytest.mark.parametrize("category_dist", ["cdf", "pdf"])
-def test_rps_category_edges_None_works(o, f_prob, category_dist):
+@pytest.mark.parametrize("input_distributions", ["c", "p"])
+def test_rps_category_edges_None_works(o, f_prob, input_distributions):
     """Test that rps expects inputs to have category_edges dim if category_edges is None."""
     o = o.rename({"time": "category"})
     f_prob = f_prob.rename({"time": "category"}).mean("member")
-    rps(o, f_prob, category_edges=None, dim=[], category_dist=category_dist)
+    rps(o, f_prob, category_edges=None, dim=[], input_distributions=input_distributions)
 
 
 @pytest.mark.parametrize("chunk_bool", [True, False])
@@ -628,6 +628,30 @@ def test_rps_wilks_example():
     assert_allclose(rps(Obs, F2, category_edges), rps(Obs, F2, xr_category_edges))
 
 
+def test_rps_wilks_example_pdf():
+    """Test xs.rps(category_edges=None, input_distributions='p') with values from Wilks, D. S. (2006). Statistical methods in the
+    atmospheric sciences (2nd ed, Vol. 91). Amsterdam ; Boston: Academic Press. p.301.
+    """
+    Obs = xr.DataArray([1.0, 0.0, 0.0], dims="category")  # no precip
+    F1 = xr.DataArray([0.2, 0.5, 0.3], dims="category")
+    F2 = xr.DataArray([0.2, 0.3, 0.5], dims="category")
+    np.testing.assert_allclose(
+        rps(Obs, F1, category_edges=None, input_distributions="p"), 0.73
+    )
+    np.testing.assert_allclose(
+        rps(Obs, F2, category_edges=None, input_distributions="p"), 0.89
+    )
+
+    # second example
+    Obs = xr.DataArray([0.0, 0.0, 1.0], dims="category")  # larger than 0.25
+    np.testing.assert_allclose(
+        rps(Obs, F1, category_edges=None, input_distributions="p"), 0.53
+    )
+    np.testing.assert_allclose(
+        rps(Obs, F2, category_edges=None, input_distributions="p"), 0.29
+    )
+
+
 @pytest.mark.parametrize("fair_bool", [True, False])
 def test_2_category_rps_equals_brier_score(o, f_prob, fair_bool):
     """Test that RPS for two categories equals the Brier Score."""
@@ -654,7 +678,7 @@ def test_rps_fair_category_edges_None(o, f_prob):
         category_edges=None,
         dim=None,
         fair=True,
-        category_dist="pdf",
+        input_distributions="p",
     )
 
 
@@ -742,8 +766,8 @@ def test_rps_category_edges_tuple(o, f_prob, fair_bool):
     assert "category_edge" not in actual.dims
 
 
-@pytest.mark.parametrize("category_dist", ["cdf", "pdf"])
-def test_rps_category_edges_None(o, f_prob, category_dist):
+@pytest.mark.parametrize("input_distributions", ["c", "p"])
+def test_rps_category_edges_None(o, f_prob, input_distributions):
     """Test rps with category_edges as None expecting o and f_prob are already CDFs."""
     e = [0, 0.2, 0.4, 0.6, 0.8, 1.0]
     bin_dim = "category"
@@ -756,7 +780,7 @@ def test_rps_category_edges_None(o, f_prob, category_dist):
         dim="time",
         fair=False,
         category_edges=None,
-        category_dist=category_dist,
+        input_distributions=input_distributions,
     )
     assert set(["lon", "lat"]) == set(actual.dims)
     assert "quantile" not in actual.dims

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -731,9 +731,12 @@ def test_rps_category_edges_None(o, f_prob, fair_bool):
     edges = xr.DataArray(e, dims=bin_dim, coords={bin_dim: e})
     o_c = o < edges  # CDF
     f_prob_c = f_prob < edges  # CDF
+    print(o_c)
+    print(f_c)
     actual = rps(o_c, f_prob_c, dim="time", fair=fair_bool, category_edges=None)
     assert set(["lon", "lat"]) == set(actual.dims)
     assert "quantile" not in actual.dims
+    assert "member" not in actual.dims
 
 
 @pytest.mark.parametrize(

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -723,8 +723,7 @@ def test_rps_category_edges_tuple(o, f_prob, fair_bool):
     assert "category_edge" not in actual.dims
 
 
-@pytest.mark.parametrize("fair_bool", [True, False])
-def test_rps_category_edges_None(o, f_prob, fair_bool):
+def test_rps_category_edges_None(o, f_prob):
     """Test rps with category_edges as None expecting o and f_prob are already CDFs."""
     e = [0, 0.2, 0.4, 0.6, 0.8, 1.0]
     bin_dim = "category"
@@ -733,7 +732,7 @@ def test_rps_category_edges_None(o, f_prob, fair_bool):
     f_c = (f_prob < edges).mean("member")  # CDF
     print(o_c)
     print(f_c)
-    actual = rps(o_c, f_c, dim="time", fair=fair_bool, category_edges=None)
+    actual = rps(o_c, f_c, dim="time", fair=False, category_edges=None)
     print(actual)
     assert set(["lon", "lat"]) == set(actual.dims)
     assert "quantile" not in actual.dims

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -476,7 +476,7 @@ def test_rps_category_edges_None_fails(o, f_prob):
 def test_rps_category_edges_None_works(o, f_prob):
     """Test that rps expects inputs to have category_edges dim if category_edges is None."""
     o = o.rename({"time": "category_edge"})
-    f_prob = f_prob.rename({"time": "category_edge"}).mean("member")
+    f_prob = f_prob.rename({"time": "category"}).mean("member")
     rps(o, f_prob, category_edges=None, dim=[])
 
 
@@ -727,7 +727,7 @@ def test_rps_category_edges_tuple(o, f_prob, fair_bool):
 def test_rps_category_edges_None(o, f_prob, fair_bool):
     """Test rps with category_edges as None expecting o and f_prob are already CDFs."""
     e = [0, 0.2, 0.4, 0.6, 0.8, 1.0]
-    bin_dim = "category_edge"
+    bin_dim = "category"
     edges = xr.DataArray(e, dims=bin_dim, coords={bin_dim: e})
     o_c = o < edges  # CDF
     f_prob_c = f_prob < edges  # CDF

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -732,7 +732,7 @@ def test_rps_category_edges_None(o, f_prob, fair_bool):
     o_c = o < edges  # CDF
     f_prob_c = f_prob < edges  # CDF
     print(o_c)
-    print(f_c)
+    print(f_prob_c)
     actual = rps(o_c, f_prob_c, dim="time", fair=fair_bool, category_edges=None)
     assert set(["lon", "lat"]) == set(actual.dims)
     assert "quantile" not in actual.dims

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -633,10 +633,28 @@ def test_2_category_rps_equals_brier_score(o, f_prob, fair_bool):
     """Test that RPS for two categories equals the Brier Score."""
     category_edges = np.array([0.0, 0.5, 1.0])
     assert_allclose(
-        rps(o, f_prob, category_edges=category_edges, dim=None, fair=fair_bool).drop(
-            ["forecasts_category_edge", "observations_category_edge"]
-        ),
+        rps(
+            o.rename({"time": "category"}),
+            f_prob.rename({"time": "category"}),
+            category_edges=category_edges,
+            dim=None,
+            fair=fair_bool,
+        ).drop(["forecasts_category_edge", "observations_category_edge"]),
         brier_score(o > 0.5, (f_prob > 0.5), dim=None, fair=fair_bool),
+    )
+
+
+def test_rps_fair_category_edges_None(o, f_prob):
+    """Test that RPS without category_edges works for fair==True if forecast[member] set."""
+    rps(
+        o.rename({"time": "category"}),
+        f_prob.mean("member")
+        .rename({"time": "category"})
+        .assign_coords(member=f_prob.member.size),
+        category_edges=None,
+        dim=None,
+        fair=True,
+        category_dist="pdf",
     )
 
 

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -629,8 +629,9 @@ def test_rps_wilks_example():
 
 
 def test_rps_wilks_example_pdf():
-    """Test xs.rps(category_edges=None, input_distributions='p') with values from Wilks, D. S. (2006). Statistical methods in the
-    atmospheric sciences (2nd ed, Vol. 91). Amsterdam ; Boston: Academic Press. p.301.
+    """Test xs.rps(category_edges=None, input_distributions='p') with values from
+    Wilks, D. S. (2006). Statistical methods in the atmospheric sciences (2nd ed,
+    Vol. 91). Amsterdam ; Boston: Academic Press. p.301.
     """
     Obs = xr.DataArray([1.0, 0.0, 0.0], dims="category")  # no precip
     F1 = xr.DataArray([0.2, 0.5, 0.3], dims="category")
@@ -669,7 +670,8 @@ def test_2_category_rps_equals_brier_score(o, f_prob, fair_bool):
 
 
 def test_rps_fair_category_edges_None(o, f_prob):
-    """Test that RPS without category_edges works for fair==True if forecast[member] set."""
+    """Test that RPS without category_edges works for fair==True if forecast[member]
+    set."""
     rps(
         o.rename({"time": "category"}),
         f_prob.mean("member")

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -467,6 +467,19 @@ def test_rps_reduce_dim(o, f_prob, category_edges, dim, fair_bool):
     assert_only_dim_reduced(dim, actual, o)
 
 
+def test_rps_category_edges_None_fails(o, f_prob):
+    """Test that rps expects inputs to have category_edges dim if category_edges is None."""
+    with pytest.raises(ValueError, match="Expected dimension"):
+        rps(o, f_prob, category_edges=None, dim=[])
+
+
+def test_rps_category_edges_None_works(o, f_prob):
+    """Test that rps expects inputs to have category_edges dim if category_edges is None."""
+    o = o.rename({"time": "category_edge"})
+    f_prob = f_prob.rename({"time": "category_edge"}).mean("member")
+    rps(o, f_prob, category_edges=None, dim=[])
+
+
 @pytest.mark.parametrize("chunk_bool", [True, False])
 @pytest.mark.parametrize("input_type", ["Dataset", "multidim Dataset", "DataArray"])
 @pytest.mark.parametrize("keep_attrs", [True, False])

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -730,11 +730,8 @@ def test_rps_category_edges_None(o, f_prob):
     edges = xr.DataArray(e, dims=bin_dim, coords={bin_dim: e})
     o_c = o < edges  # CDF
     f_c = (f_prob < edges).mean("member")  # CDF
-    print(o_c)
-    print(f_c)
     actual = rps(o_c, f_c, dim="time", fair=False, category_edges=None)
-    print(actual)
-    assert set(["lon", "lat"]) == set(actual.dims)
+    assert set(["lon", "lat"]) == set(actual.isel(category=0, drop=True).dims)
     assert "quantile" not in actual.dims
     assert "member" not in actual.dims
 


### PR DESCRIPTION
# Description

- [x] if data is already PDF or CDF, require `category` not `category_edge` dimension.
- [x] maybe differentiate for PDF and CDFs in xs.rps if `category_edges=None`?
- [ ] ~check CDF<=1 or sum(PDF)=1 if `category_edges=None`? might trigger compute, therefore dont~

Closes #(issue)

## Type of change

Please delete options that are not relevant.

-   [ ]  Bug fix (non-breaking change which fixes an issue)
-   [x]  New feature (non-breaking change which adds functionality)
-   [x]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ]  Performance (if you touched existing code run `asv` to detect performance changes)
-   [ ]  refactoring

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. This could point to a cell in the updated notebooks. Or a snippet of code with accompanying figures here.

## Checklist (while developing)

-   [ ]  I have added docstrings to all new functions.
-   [ ]  I have commented my code, particularly in hard-to-understand areas
-   [ ]  Tests added for `pytest`, if necessary.
