### PR TITLE
use built in clip

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ Changelog History
 xskillscore v0.0.20 (2021-XX-XX)
 --------------------------------
 
+Features
+~~~~~~~~
+- Specify category distribution type with ``input_distributions`` in
+  :py:func:`~xskillscore.rps` if ``category_edges==None`` that forecasts and
+  observations are probability distributions ``p`` or cumulative
+  distributionss ``c``. See :py:func:`~xskillscore.rps` docstrings and doctests for
+  examples. (:pr:`300`) `Aaron Spring`_
+
 Internal Changes
 ~~~~~~~~~~~~~~~~
 - Use ``pytest-xdist`` and ``matplotlib-base`` in environments to speed up CI.
@@ -12,12 +20,8 @@ Internal Changes
 - :py:func:`~xskillscore.rps` does not break from masking NaNs anymore.
   :py:func:`~xskillscore.rps` expilicty checks for ``bin_dim`` if
   ``category_edges==None``. (:pr:`287`) `Aaron Spring`_
-- Specify category distribution type with ``input_distributions`` in
-  :py:func:`~xskillscore.rps` if ``category_edges==None`` that forecasts and
-  observations are probability distributions ``p`` or cumulative
-  distributionss ``c``. See :py:func:`~xskillscore.rps` docstrings and doctests for
-  examples. (:pr:`300`) `Aaron Spring`_
 - Add doctest on the docstring examples. (:pr:`302`) `Ray Bell`_
+- Use built in ``xarray`` clip method. (:pr:`309`) `Ray Bell`_
 
 
 xskillscore v0.0.19 (2021-03-12)

--- a/ci/dev.yml
+++ b/ci/dev.yml
@@ -24,7 +24,7 @@ dependencies:
   - xarray>=0.16.1
   # xhistogram 0.1.3 introduced an error that broke xskillscore
   # see https://github.com/xgcm/xhistogram/issues/48
-  - xhistogram!=0.1.3
+  - xhistogram==0.1.2
   # Package Management
   - asv
   - black

--- a/ci/doc.yml
+++ b/ci/doc.yml
@@ -21,6 +21,6 @@ dependencies:
   - xarray>=0.16.1
   # xhistogram 0.1.3 introduced an error that broke xskillscore
   # see https://github.com/xgcm/xhistogram/issues/48
-  - xhistogram!=0.1.3
+  - xhistogram==0.1.2
   - pip:
       - -e ..

--- a/ci/docs_notebooks.yml
+++ b/ci/docs_notebooks.yml
@@ -14,7 +14,7 @@ dependencies:
   - xarray>=0.16.1
   # xhistogram 0.1.3 introduced an error that broke xskillscore
   # see https://github.com/xgcm/xhistogram/issues/48
-  - xhistogram!=0.1.3
+  - xhistogram==0.1.2
   - importlib_metadata
   - jupyterlab
   - matplotlib-base

--- a/ci/minimum-tests.yml
+++ b/ci/minimum-tests.yml
@@ -15,7 +15,7 @@ dependencies:
   - xarray>=0.16.1
   # xhistogram 0.1.3 introduced an error that broke xskillscore
   # see https://github.com/xgcm/xhistogram/issues/48
-  - xhistogram!=0.1.3
+  - xhistogram==0.1.2
   - coveralls
   - pytest
   - pytest-cov

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -1153,9 +1153,9 @@ def _auc(fpr, tpr, dim="probability_bin"):
                 area = xr.apply_ufunc(
                     np.trapz, tpr, fpr, input_core_dims=[[dim], [dim]], dask="allowed"
                 )
-    area = np.abs(area)
+    area = abs(area)
     if ((area > 1)).any():
-        area = np.clip(area, 0, 1)  # allow only values between 0 and 1
+        area = area.clip(0, 1)  # allow only values between 0 and 1
     return area
 
 

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -996,7 +996,7 @@ def test_roc_bin_edges_continuous_against_sklearn(
     forecast_1d_long, observation_1d_long, drop_intermediate_bool
 ):
     """Test xs.roc against sklearn.metrics.roc_curve/auc_score."""
-    fp = np.clip(forecast_1d_long, 0, 1)  # prob
+    fp = forecast_1d_long.clip(0, 1)  # prob
     ob = observation_1d_long > 0  # binary
     # sklearn
     sk_fpr, sk_tpr, _ = roc_curve(ob, fp, drop_intermediate=drop_intermediate_bool)
@@ -1017,7 +1017,7 @@ def test_roc_bin_edges_continuous_against_sklearn(
 
 def test_roc_bin_edges_drop_intermediate(forecast_1d_long, observation_1d_long):
     """Test that drop_intermediate reduces probability_bins in xs.roc ."""
-    fp = np.clip(forecast_1d_long, 0, 1)  # prob
+    fp = forecast_1d_long.clip(0, 1)  # prob
     ob = observation_1d_long > 0  # binary
     # xs
     txs_fpr, txs_tpr, txs_area = roc(


### PR DESCRIPTION
Closes errors seen in https://github.com/xarray-contrib/xskillscore/pull/308

The latest xarray did some refactoring on the built in clip method. It broke something in xskillscore but it helped identify areas of improvement

we were calling `np.clip(xarray object, min, max)`. There is the built in clip method which is preferred:
 - https://xarray.pydata.org/en/v0.18.0/generated/xarray.DataArray.clip.html
 - https://xarray.pydata.org/en/v0.18.0/generated/xarray.Dataset.clip.html

We were calling `np.abs(xarray object)`. We can use the python abs method to do the same:
 - https://stackoverflow.com/a/46981308/6046019

For what it's worth here's how the clip refactor showed up in xskillscore.

Latest:
```
conda remove --name test_env --all --y
conda create -n test_env python=3.9 --y
conda activate test_env
mamba install -c conda-forge xarray netCDF4 pooch --y
python

import xarray as xr
import numpy as np

ds = xr.tutorial.open_dataset("air_temperature")
np.clip(ds, 0, 1) # -> TypeError: clip() got an unexpected keyword argument 'out'

exit()
conda deactivate
```

xarray v0.17.0:
```
conda remove --name test_env --all --y
conda create -n test_env python=3.9 --y
conda activate test_env
mamba install -c conda-forge xarray==0.17.0 netCDF4 pooch --y
python

import xarray as xr
import numpy as np

ds = xr.tutorial.open_dataset("air_temperature")
np.clip(ds, 0, 1) # Works
```