### PR TITLE
sync setup.cfg with .pre-commit-config.yaml

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,4 +31,8 @@ skip =
 
 [doc8]
 max-line-length = 100
-ignore-path = .eggs/
+ignore-path = .eggs/,docs/source/api/
+
+[mypy]
+ignore_missing_imports = True
+follow_imports = silent


### PR DESCRIPTION
Keep setup.cfg inline with .pre-commit-config.yaml

We leave most of the CI to pre-commit / GHA but this helps match the settings if a developer want to run one tool locally e.g. mypy