### PR TITLE
clean up docs/conf.py

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,7 +32,6 @@ print("xskillscore: %s, %s" % (xskillscore.__version__, xskillscore.__file__))
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
-    "sphinx.ext.autodoc.typehints",
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
     "sphinx.ext.extlinks",
@@ -49,13 +48,10 @@ extlinks = {
     "pr": ("https://github.com/xarray-contrib/xskillscore/pull/%s", "GH#"),
 }
 
-autodoc_typehints = "description"
-
 nbsphinx_timeout = 60
 nbsphinx_execute = "always"
 
 autosummary_generate = True
-autodoc_typehints = "none"
 
 napoleon_use_param = True
 napoleon_use_rtype = True


### PR DESCRIPTION
This could be a first step towards https://github.com/xarray-contrib/xskillscore/issues/324

I think sphinx.ext.autodoc.typehints is superfluous. I think just sphinx.ext.autodoc gives exposure to everything in https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#module-sphinx.ext.autodoc

I removed the line `autodoc_typehints = "none"`, as well as `autodoc_typehints = "description"`.

I took a peak at what others do in the PyData stack:
 - dask - https://github.com/dask/dask/blob/main/docs/source/conf.py - do nothing with autodoc
 - pandas - https://github.com/pandas-dev/pandas/blob/master/doc/source/conf.py - have `autodoc_typehints = "none"` but they have typing in the docs so not sure where it's set e.g. https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html
 - xarray - https://github.com/pydata/xarray/blob/master/doc/conf.py - have `autodoc_typehints = "none"` but do have [`napoleon_type_aliases`](https://github.com/pydata/xarray/blob/master/doc/conf.py#L121)
 - dask - https://github.com/numpy/numpy/blob/main/doc/source/conf.py - do nothing with autodoc

it worked
https://xskillscore--326.org.readthedocs.build/en/326/api/xskillscore.halfwidth_ci_test.html#xskillscore.halfwidth_ci_test

compare that to https://xskillscore.readthedocs.io/en/latest/api/xskillscore.halfwidth_ci_test.html#xskillscore.halfwidth_ci_test

Question: do we want this? If definitely isn't pretty. It's good to have typing in the codebase for development but i'm not sure on docs unless there is a better way to display it.