### PR TITLE
autodoc_typehints description

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,7 +32,6 @@ print("xskillscore: %s, %s" % (xskillscore.__version__, xskillscore.__file__))
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
-    "sphinx.ext.autodoc.typehints",
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
     "sphinx.ext.extlinks",
@@ -55,7 +54,6 @@ nbsphinx_timeout = 60
 nbsphinx_execute = "always"
 
 autosummary_generate = True
-autodoc_typehints = "none"
 
 napoleon_use_param = True
 napoleon_use_rtype = True


### PR DESCRIPTION
Another flavor of https://github.com/xarray-contrib/xskillscore/pull/326

See https://xskillscore--327.org.readthedocs.build/en/327/api/xskillscore.halfwidth_ci_test.html

Seems to add Return type.

I'm leaning to this over (#326). It's minimal change in the docs and it offers some benefit and exposure of adding typing.