### PR TITLE
Update test_probabilistic.py

### DIFF
--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -1070,3 +1070,14 @@ def test_roc_bin_edges_symmetric_asc_or_desc(
     assert_identical(fpr, fpr2.sortby(fpr.probability_bin))
     assert_identical(tpr, tpr2.sortby(tpr.probability_bin))
     assert_identical(area, area2)
+
+    
+    def test_brier_score_float_forecast_or_observations(o, f_prob):
+        """Test that forecast and observations can be float."""
+        o = o > 0.5
+        f_prob = (f_frob > 0.5).mean("member")
+        brier_score(o, f_prob)
+        brier_score(o, 0.5)
+        brier_score(0.5, f_prob)
+        
+        

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -1072,12 +1072,10 @@ def test_roc_bin_edges_symmetric_asc_or_desc(
     assert_identical(area, area2)
 
     
-    def test_brier_score_float_forecast_or_observations(o, f_prob):
-        """Test that forecast and observations can be float."""
-        o = o > 0.5
-        f_prob = (f_frob > 0.5).mean("member")
-        brier_score(o, f_prob)
-        brier_score(o, 0.5)
-        brier_score(0.5, f_prob)
-        
-        
+def test_brier_score_float_forecast_or_observations(o, f_prob):
+    """Test that forecast and observations can be float."""
+    o = o > 0.5
+    f_prob = (f_prob > 0.5).mean("member")
+    brier_score(o, f_prob)
+    brier_score(o, 0.5)
+    brier_score(0.5, f_prob)


### PR DESCRIPTION
# Description

allow float or int inputs

alternative solution: convert int and float inputs to `xr` with `xr.ones_like(forecast) * observation`

Closes #285

## Type of change

Please delete options that are not relevant.

-   [x]  Bug fix (non-breaking change which fixes an issue)
-   [ ]  New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] pytest

## Checklist (while developing)

-   [ ]  I have added docstrings to all new functions.
-   [ ]  I have commented my code, particularly in hard-to-understand areas
-   [x]  Tests added for `pytest`, if necessary.

## Pre-Merge Checklist (final steps)

-   [ ]  I have rebased onto main or develop (wherever I am merging) and dealt with any conflicts.
-   [ ]  I have squashed commits to a reasonable amount, and force-pushed the squashed commits.

## References

Please add any references to manuscripts, textbooks, etc.
