### PR TITLE
Fix `brier_score` for `float` and `int` inputs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ xskillscore v0.0.23 (2021-xx-xx)
 --------------------------------
 
 - Allow ``float`` or integer`` forecasts in :py:func:`~xskillscore.brier_score`
-  (:issue:`285`, :pr:`340`) `Aaron Spring`_
+  (:issue:`285`, :pr:`341`) `Aaron Spring`_
 
 xskillscore v0.0.22 (2021-06-29)
 --------------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog History
 xskillscore v0.0.23 (2021-xx-xx)
 --------------------------------
 
+- Allow ``float`` or integer`` forecasts in :py:func:`~xskillscore.brier_score`
+  (:issue:`285`, :pr:`340`) `Aaron Spring`_
 
 xskillscore v0.0.22 (2021-06-29)
 --------------------------------

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -350,8 +350,9 @@ def brier_score(
                 o = observations
                 res = (e / M - o) ** 2 - e * (M - e) / (M ** 2 * (M - 1))
         else:
-            if member_dim in forecasts.dims:
-                forecasts = forecasts.mean(member_dim)
+            if isinstance(forecasts, (xr.Dataset, xr.DataArray)):
+                if member_dim in forecasts.dims:
+                    forecasts = forecasts.mean(member_dim)
             res = xr.apply_ufunc(
                 properscoring.brier_score,
                 observations,

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -1070,3 +1070,14 @@ def test_roc_bin_edges_symmetric_asc_or_desc(
     assert_identical(fpr, fpr2.sortby(fpr.probability_bin))
     assert_identical(tpr, tpr2.sortby(tpr.probability_bin))
     assert_identical(area, area2)
+
+    
+    def test_brier_score_float_forecast_or_observations(o, f_prob):
+        """Test that forecast and observations can be float."""
+        o = o > 0.5
+        f_prob = (f_frob > 0.5).mean("member")
+        brier_score(o, f_prob)
+        brier_score(o, 0.5)
+        brier_score(0.5, f_prob)
+        
+        

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -1072,12 +1072,10 @@ def test_roc_bin_edges_symmetric_asc_or_desc(
     assert_identical(area, area2)
 
     
-    def test_brier_score_float_forecast_or_observations(o, f_prob):
-        """Test that forecast and observations can be float."""
-        o = o > 0.5
-        f_prob = (f_frob > 0.5).mean("member")
-        brier_score(o, f_prob)
-        brier_score(o, 0.5)
-        brier_score(0.5, f_prob)
-        
-        
+def test_brier_score_float_forecast_or_observations(o, f_prob):
+    """Test that forecast and observations can be float."""
+    o = o > 0.5
+    f_prob = (f_prob > 0.5).mean("member")
+    brier_score(o, f_prob)
+    brier_score(o, 0.5)
+    brier_score(0.5, f_prob)

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -1071,11 +1071,11 @@ def test_roc_bin_edges_symmetric_asc_or_desc(
     assert_identical(tpr, tpr2.sortby(tpr.probability_bin))
     assert_identical(area, area2)
 
-    
+
 def test_brier_score_float_forecast_or_observations(o, f_prob):
     """Test that forecast and observations can be float."""
     o = o > 0.5
     f_prob = (f_prob > 0.5).mean("member")
     brier_score(o, f_prob)
     brier_score(o, 0.5)
-    brier_score(0.5, f_prob)
+    brier_score(1, f_prob)


### PR DESCRIPTION
# Description

allow float or int inputs

alternative solution: convert int and float inputs to xr with `xr.ones_like(forecast) * observation`

Closes #285

## Type of change

Please delete options that are not relevant.

-   [x]  Bug fix (non-breaking change which fixes an issue)
-   [ ]  New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] pytest

## Checklist (while developing)

-   [ ]  I have added docstrings to all new functions.
-   [ ]  I have commented my code, particularly in hard-to-understand areas
-   [x]  Tests added for `pytest`, if necessary.
