### PR TITLE
Fix `brier_score` for `float` and `int` inputs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog History
 xskillscore v0.0.21 (2021-XX-XX)
 --------------------------------
 
-- Allow ``float`` or integer`` forecasts in :py:func:`~xskillscore.brier_score`
+- Allow ``float`` or ``integer`` forecasts in :py:func:`~xskillscore.brier_score`
   (:issue:`285`, :pr:`342`) `Aaron Spring`_
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,10 @@ Changelog History
 xskillscore v0.0.21 (2021-XX-XX)
 --------------------------------
 
+- Allow ``float`` or integer`` forecasts in :py:func:`~xskillscore.brier_score`
+  (:issue:`285`, :pr:`342`) `Aaron Spring`_
+
+
 Internal Changes
 ~~~~~~~~~~~~~~~~
 - Added mypy to linting (:pr:`320`) `Zachary Blackwood`_.

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -349,8 +349,9 @@ def brier_score(
                 o = observations
                 res = (e / M - o) ** 2 - e * (M - e) / (M ** 2 * (M - 1))
         else:
-            if member_dim in forecasts.dims:
-                forecasts = forecasts.mean(member_dim)
+            if isinstance(forecasts, (xr.Dataset, xr.DataArray)):
+                if member_dim in forecasts.dims:
+                    forecasts = forecasts.mean(member_dim)
             res = xr.apply_ufunc(
                 properscoring.brier_score,
                 observations,

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -1070,3 +1070,12 @@ def test_roc_bin_edges_symmetric_asc_or_desc(
     assert_identical(fpr, fpr2.sortby(fpr.probability_bin))
     assert_identical(tpr, tpr2.sortby(tpr.probability_bin))
     assert_identical(area, area2)
+
+
+def test_brier_score_float_forecast_or_observations(o, f_prob):
+    """Test that forecast and observations can be float."""
+    o = o > 0.5
+    f_prob = (f_prob > 0.5).mean("member")
+    brier_score(o, f_prob)
+    brier_score(o, 0.5)
+    brier_score(1, f_prob)


### PR DESCRIPTION
# Description

allow float or int inputs

alternative solution: convert int and float inputs to xr with `xr.ones_like(forecast) * observation`

Closes #285

Replaces #340 and #341

## Type of change

Please delete options that are not relevant.

-   [x]  Bug fix (non-breaking change which fixes an issue)
-   [ ]  New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] pytest

## Checklist (while developing)

-   [ ]  I have added docstrings to all new functions.
-   [ ]  I have commented my code, particularly in hard-to-understand areas
-   [x]  Tests added for `pytest`, if necessary.
