### PR TITLE
remove unneccessary dependencies

### DIFF
--- a/.github/workflows/cancel-duplicate-runs.yaml
+++ b/.github/workflows/cancel-duplicate-runs.yaml
@@ -8,7 +8,6 @@ jobs:
   cancel:
     name: Cancel previous runs
     runs-on: ubuntu-latest
-    if: github.repository == "xarray-contrib/xskillscore"
     steps:
     - uses: styfle/cancel-workflow-action@0.9.1
       with:

--- a/.github/workflows/cancel-duplicate-runs.yaml
+++ b/.github/workflows/cancel-duplicate-runs.yaml
@@ -8,7 +8,7 @@ jobs:
   cancel:
     name: Cancel previous runs
     runs-on: ubuntu-latest
-    if: github.repository == 'xarray-contrib/xskillscore'
+    if: github.repository == "xarray-contrib/xskillscore"
     steps:
     - uses: styfle/cancel-workflow-action@0.9.1
       with:

--- a/.github/workflows/cancel-duplicate-runs.yaml
+++ b/.github/workflows/cancel-duplicate-runs.yaml
@@ -8,7 +8,8 @@ jobs:
   cancel:
     name: Cancel previous runs
     runs-on: ubuntu-latest
+    if: github.repository == 'xarray-contrib/xskillscore'
     steps:
-    - uses: styfle/cancel-workflow-action@0.9.0
+    - uses: styfle/cancel-workflow-action@0.9.1
       with:
         workflow_id: ${{ github.event.workflow.id }}

--- a/.github/workflows/xskillscore_testing.yml
+++ b/.github/workflows/xskillscore_testing.yml
@@ -59,7 +59,9 @@ jobs:
 
   doctest:  # Tests all docstrings
     name: Doctests
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
+    needs: detect-ci-trigger
+    if: needs.detect-ci-trigger.outputs.triggered == 'false'
     defaults:
       run:
         shell: bash -l {0}
@@ -67,12 +69,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
         with:
+          auto-update-conda: true
           channels: conda-forge
-          channel-priority: strict
-          mamba-version: "*"
+          mamba-version: '*'
           activate-environment: xskillscore-minimum-tests
-          auto-update-conda: false
-          python-version: "3.8"
+          python-version: 3.8
       - name: Set up conda environment
         run: |
           mamba env update -f ci/minimum-tests.yml

--- a/.github/workflows/xskillscore_testing.yml
+++ b/.github/workflows/xskillscore_testing.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Set up conda
@@ -71,7 +71,7 @@ jobs:
         with:
           auto-update-conda: true
           channels: conda-forge
-          mamba-version: '*'
+          mamba-version: "*"
           activate-environment: xskillscore-minimum-tests
           python-version: 3.8
       - name: Set up conda environment
@@ -102,7 +102,7 @@ jobs:
         with:
           auto-update-conda: true
           channels: conda-forge
-          mamba-version: '*'
+          mamba-version: "*"
           activate-environment: xskillscore-docs-notebooks
           python-version: 3.8
       - name: Set up conda environment

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,18 @@
 Changelog History
 =================
 
+
+xskillscore v0.0.25 (2021-xx-xx)
+--------------------------------
+
+Internal Changes
+~~~~~~~~~~~~~~~~
+- Reduce dependencies (:issue:`359`, :pr:`363`) `Aaron Spring`_.
+
+
 xskillscore v0.0.24 (2021-10-08)
 --------------------------------
+
 Documentation
 ~~~~~~~~~~~~~
 - Replaced Boston house data in ``tabular.ipynb`` (:pr:`352`) `Ray Bell`_.

--- a/ci/dev.yml
+++ b/ci/dev.yml
@@ -15,7 +15,7 @@ dependencies:
   # Numerics
   - bottleneck
   - cftime
-  - dask
+  - dask-core
   - numba>=0.52
   - numpy
   - properscoring

--- a/ci/doc.yml
+++ b/ci/doc.yml
@@ -21,5 +21,6 @@ dependencies:
   - xarray>=0.16.1
   - xhistogram>=0.3.0
   - scikit-learn
+  - cftime
   - pip:
       - -e ..

--- a/ci/doc.yml
+++ b/ci/doc.yml
@@ -22,5 +22,6 @@ dependencies:
   - xhistogram>=0.3.0
   - scikit-learn
   - cftime
+  - dask-core
   - pip:
       - -e ..

--- a/ci/doc.yml
+++ b/ci/doc.yml
@@ -17,6 +17,7 @@ dependencies:
   - sphinx
   - sphinx_rtd_theme
   - sphinx-autosummary-accessors
+  - sphinx-copybutton
   - toolz
   - xarray>=0.16.1
   - xhistogram>=0.3.0

--- a/ci/doc.yml
+++ b/ci/doc.yml
@@ -20,5 +20,6 @@ dependencies:
   - toolz
   - xarray>=0.16.1
   - xhistogram>=0.3.0
+  - scikit-learn
   - pip:
       - -e ..

--- a/ci/docs_notebooks.yml
+++ b/ci/docs_notebooks.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - bottleneck
   - cftime
-  - dask
+  - dask-core
   - numba>=0.52
   - numpy
   - properscoring

--- a/ci/minimum-tests.yml
+++ b/ci/minimum-tests.yml
@@ -2,14 +2,15 @@ name: xskillscore-minimum-tests
 channels:
   - conda-forge
 dependencies:
-  - bottleneck
   - numpy
   - properscoring
   - scipy
   - xarray>=0.16.1
   - xhistogram>=0.3.0
-  - coveralls
   - cftime
+  - scikit-learn
+  - bottleneck
+  - coveralls
   - pytest
   - pytest-cov
   - pytest-lazy-fixture

--- a/ci/minimum-tests.yml
+++ b/ci/minimum-tests.yml
@@ -11,6 +11,7 @@ dependencies:
   - scikit-learn
   - bottleneck
   - coveralls
+  - matplotlib
   - pytest
   - pytest-cov
   - pytest-lazy-fixture

--- a/ci/minimum-tests.yml
+++ b/ci/minimum-tests.yml
@@ -12,7 +12,7 @@ dependencies:
   - dask-core
   - bottleneck
   - coveralls
-  - matplotlib
+  - matplotlib-base
   - pytest
   - pytest-cov
   - pytest-lazy-fixture

--- a/ci/minimum-tests.yml
+++ b/ci/minimum-tests.yml
@@ -9,6 +9,7 @@ dependencies:
   - xhistogram>=0.3.0
   - cftime
   - scikit-learn
+  - dask-core
   - bottleneck
   - coveralls
   - matplotlib

--- a/ci/minimum-tests.yml
+++ b/ci/minimum-tests.yml
@@ -9,6 +9,7 @@ dependencies:
   - xarray>=0.16.1
   - xhistogram>=0.3.0
   - coveralls
+  - cftime
   - pytest
   - pytest-cov
   - pytest-lazy-fixture

--- a/ci/minimum-tests.yml
+++ b/ci/minimum-tests.yml
@@ -1,16 +1,10 @@
 name: xskillscore-minimum-tests
 channels:
   - conda-forge
-  - nodefaults
 dependencies:
   - bottleneck
-  - cftime
-  - dask
-  - matplotlib-base
-  - numba>=0.52
   - numpy
   - properscoring
-  - scikit-learn
   - scipy
   - xarray>=0.16.1
   - xhistogram>=0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 bottleneck
-cftime
 dask
 numpy
 properscoring

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-bottleneck
 numpy
 properscoring
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 numpy
+xarray>=0.16.1
+xhistogram>=0.3.0
+dask
 properscoring
 scipy
 toolz
-xarray>=0.16.1
-xhistogram>=0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 bottleneck
-dask
 numpy
 properscoring
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 bottleneck
 cftime
 dask
-numba>=0.52
 numpy
 properscoring
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 xarray>=0.16.1
 xhistogram>=0.3.0
-dask
+dask[array]
 properscoring
 scipy
 toolz

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,17 @@ EXTRAS_REQUIRE["test"] = [
     "pytest-lazyfixures",
     "pre-commit",
 ]
+EXTRAS_REQUIRE["docs"] = EXTRAS_REQUIRE["complete"] + [
+    "importlib_metadata",
+    "nbsphinx",
+    "nbstripout",
+    "doc8",
+    "sphinx",
+    "sphinx-autosummary-accessors",
+    "sphinxcontrib-napoleon",
+    "sphinx_rtd_theme",
+    "sphinx-copybutton",
+]
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -12,14 +12,13 @@ with open("requirements.txt") as f:
 TESTS_REQUIRE = ["pytest", "scikit-learn", "cftime", "dask", "matplotlib", "pytest-cov", "pytest-lazyfixures"]
 PYTHON_REQUIRE = ">=3.7"
 
-extras_require=(
-    {
-        "accel": ["numba>=0.52", "bottleneck"],
-    }
-)
+extras_require = {
+    "accel": ["numba>=0.52", "bottleneck"],
+}
+
 extras_require["complete"] = sorted({v for req in extras_require.values() for v in req})
 # after complete is set, add in test
-extras_require['test'] = [
+extras_require["test"] = [
     "pytest",
     "scikit-learn",
     "cftime",
@@ -27,7 +26,7 @@ extras_require['test'] = [
     "matplotlib",
     "pytest-cov",
     "pytest-xdist",
-    "pytest-lazyfixures"
+    "pytest-lazyfixures",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ LONG_DESCRIPTION = """Metrics for verifying forecasts"""
 URL = "https://github.com/xarray-contrib/xskillscore"
 with open("requirements.txt") as f:
     INSTALL_REQUIRES = f.read().strip().split("\n")
-TESTS_REQUIRE = ["pytest", "scikit-learn", "cftime", "dask.array"]
+TESTS_REQUIRE = ["pytest", "scikit-learn", "cftime", "dask[array]"]
 PYTHON_REQUIRE = ">=3.7"
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,24 @@ LONG_DESCRIPTION = """Metrics for verifying forecasts"""
 URL = "https://github.com/xarray-contrib/xskillscore"
 with open("requirements.txt") as f:
     INSTALL_REQUIRES = f.read().strip().split("\n")
-TESTS_REQUIRE = ["pytest", "scikit-learn", "cftime", "dask[array]", "matplotlib"]
+TESTS_REQUIRE = ["pytest", "scikit-learn", "cftime", "dask[array]", "matplotlib", "pytest-cov", "pytest-lazyfixures"]
 PYTHON_REQUIRE = ">=3.7"
+
+extras_require={
+    "accel": ["numba>=0.52", "bottleneck"],
+},
+extras_require["complete"] = sorted({v for req in extras_require.values() for v in req})
+# after complete is set, add in test
+extras_require['test'] = [
+    "pytest",
+    "scikit-learn",
+    "cftime",
+    "dask[array]",
+    "matplotlib",
+    "pytest-cov",
+    "pytest-xdist"
+    "pytest-lazyfixures"
+]
 
 
 setup(
@@ -24,7 +40,7 @@ setup(
     packages=find_packages(),
     install_requires=INSTALL_REQUIRES,
     test_suite="xskillscore/tests",
-    tests_require=TESTS_REQUIRE,
+    tests_require=["pytest"],
     python_requires=PYTHON_REQUIRE,
     use_scm_version={"version_scheme": "post-release", "local_scheme": "dirty-tag"},
     setup_requires=[
@@ -32,8 +48,6 @@ setup(
         "setuptools>=30.3.0",
         "setuptools_scm_git_archive",
     ],
-    extras_require={
-        "accel": ["numba>=0.52", "bottleneck"],
-    },
+    extras_require=extras_require,
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ LONG_DESCRIPTION = """Metrics for verifying forecasts"""
 URL = "https://github.com/xarray-contrib/xskillscore"
 with open("requirements.txt") as f:
     INSTALL_REQUIRES = f.read().strip().split("\n")
-TESTS_REQUIRE = ["pytest", "scikit-learn", "cftime", "dask[array]"]
+TESTS_REQUIRE = ["pytest", "scikit-learn", "cftime", "dask[array]", "matplotlib"]
 PYTHON_REQUIRE = ">=3.7"
 
 

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,11 @@ with open("requirements.txt") as f:
 TESTS_REQUIRE = ["pytest", "scikit-learn", "cftime", "dask", "matplotlib", "pytest-cov", "pytest-lazyfixures"]
 PYTHON_REQUIRE = ">=3.7"
 
-extras_require={
-    "accel": ["numba>=0.52", "bottleneck"],
-},
+extras_require=(
+    {
+        "accel": ["numba>=0.52", "bottleneck"],
+    }
+)
 extras_require["complete"] = sorted({v for req in extras_require.values() for v in req})
 # after complete is set, add in test
 extras_require['test'] = [
@@ -24,7 +26,7 @@ extras_require['test'] = [
     "dask[array]",
     "matplotlib",
     "pytest-cov",
-    "pytest-xdist"
+    "pytest-xdist",
     "pytest-lazyfixures"
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -11,13 +11,13 @@ with open("requirements.txt") as f:
     INSTALL_REQUIRES = f.read().strip().split("\n")
 PYTHON_REQUIRE = ">=3.7"
 
-extras_require = {
+EXTRAS_REQUIRE = {
     "accel": ["numba>=0.52", "bottleneck"],
 }
 
-extras_require["complete"] = sorted({v for req in extras_require.values() for v in req})
+EXTRAS_REQUIRE["complete"] = sorted({v for req in EXTRAS_REQUIRE.values() for v in req})
 # after complete is set, add in test
-extras_require["test"] = [
+EXTRAS_REQUIRE["test"] = [
     "pytest",
     "scikit-learn",
     "cftime",
@@ -48,6 +48,6 @@ setup(
         "setuptools>=30.3.0",
         "setuptools_scm_git_archive",
     ],
-    extras_require=extras_require,
+    extras_require=EXTRAS_REQUIRE,
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ LONG_DESCRIPTION = """Metrics for verifying forecasts"""
 URL = "https://github.com/xarray-contrib/xskillscore"
 with open("requirements.txt") as f:
     INSTALL_REQUIRES = f.read().strip().split("\n")
-TESTS_REQUIRE = ["pytest", "scikit-learn", "cftime", "dask[array]", "matplotlib", "pytest-cov", "pytest-lazyfixures"]
+TESTS_REQUIRE = ["pytest", "scikit-learn", "cftime", "dask", "matplotlib", "pytest-cov", "pytest-lazyfixures"]
 PYTHON_REQUIRE = ">=3.7"
 
 extras_require={

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ LONG_DESCRIPTION = """Metrics for verifying forecasts"""
 URL = "https://github.com/xarray-contrib/xskillscore"
 with open("requirements.txt") as f:
     INSTALL_REQUIRES = f.read().strip().split("\n")
-TESTS_REQUIRE = ["pytest", "scikit-learn", "cftime"]
+TESTS_REQUIRE = ["pytest", "scikit-learn", "cftime", "dask.array"]
 PYTHON_REQUIRE = ">=3.7"
 
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ EXTRAS_REQUIRE["test"] = [
     "pytest-cov",
     "pytest-xdist",
     "pytest-lazyfixures",
+    "pre-commit",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,8 @@ setup(
         "setuptools>=30.3.0",
         "setuptools_scm_git_archive",
     ],
+    extras_require={
+        "accel": ["numba>=0.52", "bottleneck"],
+    },
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ LONG_DESCRIPTION = """Metrics for verifying forecasts"""
 URL = "https://github.com/xarray-contrib/xskillscore"
 with open("requirements.txt") as f:
     INSTALL_REQUIRES = f.read().strip().split("\n")
-TESTS_REQUIRE = ["pytest", "scikit-learn", "cftime", "dask", "matplotlib", "pytest-cov", "pytest-lazyfixures"]
 PYTHON_REQUIRE = ">=3.7"
 
 extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ EXTRAS_REQUIRE["test"] = [
     "pytest",
     "scikit-learn",
     "cftime",
-    "dask[array]",
     "matplotlib",
     "pytest-cov",
     "pytest-xdist",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ LONG_DESCRIPTION = """Metrics for verifying forecasts"""
 URL = "https://github.com/xarray-contrib/xskillscore"
 with open("requirements.txt") as f:
     INSTALL_REQUIRES = f.read().strip().split("\n")
-TESTS_REQUIRE = ["pytest", "scikit-learn"]
+TESTS_REQUIRE = ["pytest", "scikit-learn", "cftime"]
 PYTHON_REQUIRE = ">=3.7"
 
 

--- a/xskillscore/core/np_deterministic.py
+++ b/xskillscore/core/np_deterministic.py
@@ -5,6 +5,12 @@ from scipy.stats import distributions
 
 from .utils import suppress_warnings
 
+try:
+    from bottleneck import nanrankdata as rankdata
+except ImportError:
+    from scipy.stats import rankdata
+
+
 __all__ = [
     "_effective_sample_size",
     "_linslope",
@@ -447,8 +453,8 @@ def _spearman_r(a, b, weights, axis, skipna):
     """
     if skipna:
         a, b, weights = _match_nans(a, b, weights)
-    _a = bn.nanrankdata(a, axis=axis)
-    _b = bn.nanrankdata(b, axis=axis)
+    _a = rankdata(a, axis=axis)
+    _b = rankdata(b, axis=axis)
     return _pearson_r(_a, _b, weights, axis, skipna)
 
 

--- a/xskillscore/core/np_deterministic.py
+++ b/xskillscore/core/np_deterministic.py
@@ -1,4 +1,3 @@
-import bottleneck as bn
 import numpy as np
 from scipy import special
 from scipy.stats import distributions

--- a/xskillscore/core/np_probabilistic.py
+++ b/xskillscore/core/np_probabilistic.py
@@ -41,6 +41,7 @@ def _reliability(o, f, bin_edges):
 
     if is_dask_array:
         import dask.array as da
+
         return (
             da.stack(r, axis=-1).rechunk({-1: -1}),
             da.stack(N, axis=-1).rechunk({-1: -1}),

--- a/xskillscore/core/np_probabilistic.py
+++ b/xskillscore/core/np_probabilistic.py
@@ -1,5 +1,5 @@
 import numpy as np
-
+import dask.array as da
 from .utils import suppress_warnings
 
 __all__ = ["_reliability"]
@@ -40,8 +40,8 @@ def _reliability(o, f, bin_edges):
 
     if is_dask_array:
         return (
-            r.stack(axis=-1).rechunk({-1: -1}),
-            N.stack(axis=-1).rechunk({-1: -1}),
+            da.stack(r, axis=-1).rechunk({-1: -1}),
+            da.stack(N, axis=-1).rechunk({-1: -1}),
         )
     else:
         return r, N

--- a/xskillscore/core/np_probabilistic.py
+++ b/xskillscore/core/np_probabilistic.py
@@ -9,6 +9,7 @@ def _reliability(o, f, bin_edges):
     """Return the reliability and number of samples per bin"""
     # I couldn't get dask='parallelized' working in this case
     # so dealing with dask arrays explicitly
+    # if true, imports dask.array later
     is_dask_array = not isinstance(o, np.ndarray) or not isinstance(f, np.ndarray)
 
     if is_dask_array:

--- a/xskillscore/core/np_probabilistic.py
+++ b/xskillscore/core/np_probabilistic.py
@@ -10,7 +10,7 @@ def _reliability(o, f, bin_edges):
     """Return the reliability and number of samples per bin"""
     # I couldn't get dask='parallelized' working in this case
     # so dealing with dask arrays explicitly
-    is_dask_array = not isinstance(o, np.ndarray) or not isinstance(f, np.ndarray) 
+    is_dask_array = not isinstance(o, np.ndarray) or not isinstance(f, np.ndarray)
 
     if is_dask_array:
         r = []

--- a/xskillscore/core/np_probabilistic.py
+++ b/xskillscore/core/np_probabilistic.py
@@ -1,5 +1,6 @@
-import numpy as np
 import dask.array as da
+import numpy as np
+
 from .utils import suppress_warnings
 
 __all__ = ["_reliability"]

--- a/xskillscore/core/np_probabilistic.py
+++ b/xskillscore/core/np_probabilistic.py
@@ -1,4 +1,3 @@
-import dask.array as da
 import numpy as np
 
 from .utils import suppress_warnings
@@ -40,6 +39,7 @@ def _reliability(o, f, bin_edges):
                     N[..., i] = N_f_in_bin
 
     if is_dask_array:
+        import dask.array as da
         return (
             da.stack(r, axis=-1).rechunk({-1: -1}),
             da.stack(N, axis=-1).rechunk({-1: -1}),

--- a/xskillscore/core/np_probabilistic.py
+++ b/xskillscore/core/np_probabilistic.py
@@ -9,7 +9,7 @@ def _reliability(o, f, bin_edges):
     """Return the reliability and number of samples per bin"""
     # I couldn't get dask='parallelized' working in this case
     # so dealing with dask arrays explicitly
-    is_dask_array = o.chunksizes is None | f.chunksizes is None
+    is_dask_array = not isinstance(o, np.ndarray) or not isinstance(f, np.ndarray) 
 
     if is_dask_array:
         r = []

--- a/xskillscore/core/np_probabilistic.py
+++ b/xskillscore/core/np_probabilistic.py
@@ -1,4 +1,3 @@
-import dask.array as da
 import numpy as np
 
 from .utils import suppress_warnings
@@ -10,7 +9,7 @@ def _reliability(o, f, bin_edges):
     """Return the reliability and number of samples per bin"""
     # I couldn't get dask='parallelized' working in this case
     # so dealing with dask arrays explicitly
-    is_dask_array = isinstance(o, da.core.Array) | isinstance(f, da.core.Array)
+    is_dask_array = o.chunksizes is None | f.chunksizes is None
 
     if is_dask_array:
         r = []

--- a/xskillscore/core/np_probabilistic.py
+++ b/xskillscore/core/np_probabilistic.py
@@ -40,8 +40,8 @@ def _reliability(o, f, bin_edges):
 
     if is_dask_array:
         return (
-            da.stack(r, axis=-1).rechunk({-1: -1}),
-            da.stack(N, axis=-1).rechunk({-1: -1}),
+            r.stack(axis=-1).rechunk({-1: -1}),
+            N.stack(axis=-1).rechunk({-1: -1}),
         )
     else:
         return r, N

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -1,5 +1,4 @@
 import bottleneck as bn
-import dask.array as darray
 import numpy as np
 import properscoring
 import xarray as xr

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -1,4 +1,3 @@
-import bottleneck as bn
 import numpy as np
 import properscoring
 import xarray as xr
@@ -17,6 +16,11 @@ from .utils import (
     histogram,
     suppress_warnings,
 )
+
+try:
+    from bottleneck import nanrankdata as rankdata
+except ImportError:
+    from scipy.stats import rankdata
 
 __all__ = [
     "brier_score",
@@ -873,7 +877,7 @@ def rank_histogram(observations, forecasts, dim=None, member_dim="member"):
         """Concatenates x and y and returns the rank of the
         first element along the last axes"""
         xy = np.concatenate((x[..., np.newaxis], y), axis=-1)
-        return bn.nanrankdata(xy, axis=-1)[..., 0]
+        return rankdata(xy, axis=-1)[..., 0]
 
     if dim is not None:
         if len(dim) == 0:

--- a/xskillscore/core/resampling.py
+++ b/xskillscore/core/resampling.py
@@ -1,4 +1,3 @@
-import dask
 import numpy as np
 import xarray as xr
 


### PR DESCRIPTION
# Description

- [x] make `bottleneck` extra dependency, use `scipy.stats.rankdata` if not installed
- [x] make `numba` extra dependency
- [x] make `cftime`, `scikit-learn` used for tests only
- [ ] `dask` works after https://github.com/xgcm/xhistogram/pull/71 to be merged/released

sorry for https://github.com/xarray-contrib/xskillscore/commit/61d93b387dbce709e7a0cfce7eba45d8dce946b4, I played with the github VSCode integration and just pressing `.` in the browser repo and accidentally committed to `main`

Closes #359

## Type of change

-   [x]  refactoring
- [x] dependencies

# How Has This Been Tested?

- [x] pytest
