### PR TITLE
`rank_histogram` tied ranks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,9 +6,14 @@ Changelog History
 xskillscore v0.0.25 (2021-xx-xx)
 --------------------------------
 
+Bug Fixes
+~~~~~~~~~
+- :py:func:`~xskillscore.rank_histogram` handle tied ranks correctly.
+  (:issue:`359`, :pr:`363`) `Aaron Spring`_.
+
 Internal Changes
 ~~~~~~~~~~~~~~~~
-- Reduce dependencies (:issue:`359`, :pr:`363`) `Aaron Spring`_.
+- Reduce dependencies (:issue:`335`, :pr:`364`) `Aaron Spring`_.
 
 
 xskillscore v0.0.24 (2021-10-08)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,12 +8,12 @@ xskillscore v0.0.25 (2021-xx-xx)
 
 Bug Fixes
 ~~~~~~~~~
-- :py:func:`~xskillscore.rank_histogram` handle tied ranks correctly.
-  (:issue:`359`, :pr:`363`) `Aaron Spring`_.
+- :py:func:`~xskillscore.rank_histogram` handles tied ranks correctly.
+  (:issue:`335`, :pr:`364`) `Aaron Spring`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
-- Reduce dependencies (:issue:`335`, :pr:`364`) `Aaron Spring`_.
+- Reduce dependencies (:issue:`359`, :pr:`363`) `Aaron Spring`_.
 
 
 xskillscore v0.0.24 (2021-10-08)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,8 +8,9 @@ xskillscore v0.0.25 (2021-xx-xx)
 
 Bug Fixes
 ~~~~~~~~~
-- :py:func:`~xskillscore.rank_histogram` handles tied ranks correctly.
-  (:issue:`335`, :pr:`364`) `Aaron Spring`_.
+- :py:func:`~xskillscore.rank_histogram` ``random_for_tied=True`` handles tied ranks
+  correctly by default. ``random_for_tied=False`` ignores this and retains previous
+  behaviour. (:issue:`335`, :pr:`364`) `Aaron Spring`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -899,7 +899,7 @@ def rank_histogram(
         """Concatenates x and y and returns the rank of the
         first element along the last axes"""
         xy = np.concatenate((x[..., np.newaxis], y), axis=-1)
-        ranks = scipy.stats.rankdata(xy, axis=-1, method="min')
+        ranks = scipy.stats.rankdata(xy, axis=-1, method="min")
         if random_for_tied:
             ranks = np.apply_along_axis(lambda x: add_random_tie(x), -1, ranks)
         ranks = ranks[..., 0]  # take obs rank

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -900,9 +900,11 @@ def rank_histogram(
         """Concatenates x and y and returns the rank of the
         first element along the last axes"""
         xy = np.concatenate((x[..., np.newaxis], y), axis=-1)
-        ranks = scipy.stats.rankdata(xy, axis=-1, method="min")
         if random_for_tied:
+            ranks = scipy.stats.rankdata(xy, axis=-1, method="min")
             ranks = np.apply_along_axis(lambda x: add_random_tie(x), -1, ranks)
+        else:
+            ranks = rankdata(xy, axis=-1)
         ranks = ranks[..., 0]  # take obs rank
         return ranks
 

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -880,16 +880,16 @@ def rank_histogram(observations, forecasts, dim=None, member_dim="member", rando
     -----
     See http://www.cawcr.gov.au/projects/verification/
     """
-    def add_random_tie(dr):
+    def add_random_tie(ranks):
         """Modify tied ranks by generating random rank."""
         # add experimental warning linking issue and PR
-        u, counts = np.unique(dr, return_counts=True,axis=-1)
+        u, counts = np.unique(ranks, return_counts=True, axis=-1)
         for i,count in enumerate(counts):
             if count > 1:
-                ix=dr==u[i] # index where to add random # raises warning
-                if dr[ix].shape[0]!=0:
-                    dr[ix] = dr[ix] + np.random.randint(0,min(forecasts.member.size+1,count),count) ## increase random rank
-        return dr
+                ix = ranks == u[i] # index where to add random # raises warning
+                if ranks[ix].shape[0] != 0:
+                    ranks[ix] = ranks[ix] + np.random.randint(0, min(forecasts.member.size + 1, count), len(ranks[ix])) ## increase random rank
+        return ranks
 
     def _rank_first(x, y):
         """Concatenates x and y and returns the rank of the

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -16,6 +16,7 @@ from .utils import (
     histogram,
     suppress_warnings,
 )
+import scipy.stats
 
 try:
     from bottleneck import nanrankdata as rankdata
@@ -830,7 +831,9 @@ def rps(
     return res
 
 
-def rank_histogram(observations, forecasts, dim=None, member_dim="member", random_for_tied=True):
+def rank_histogram(
+    observations, forecasts, dim=None, member_dim="member", random_for_tied=True
+):
     """Returns the rank histogram (Talagrand diagram) along the specified dimensions.
 
     Parameters
@@ -886,8 +889,8 @@ def rank_histogram(observations, forecasts, dim=None, member_dim="member", rando
         unique, counts = np.unique(ranks, return_counts=True, axis=-1)
         for i, count in enumerate(counts):
             if count > 1:  # duplicate
-                ix = ranks == unique[i] # index where to add random
-                r = np.arange(counts[i])  # counts
+                ix = ranks == unique[i]  # index where to add random
+                r = np.arange(counts[i])
                 np.random.shuffle(r)
                 ranks[ix] += r
         return ranks
@@ -896,11 +899,10 @@ def rank_histogram(observations, forecasts, dim=None, member_dim="member", rando
         """Concatenates x and y and returns the rank of the
         first element along the last axes"""
         xy = np.concatenate((x[..., np.newaxis], y), axis=-1)
-        import scipy.stats
         ranks = scipy.stats.rankdata(xy, axis=-1, method='min')
         if random_for_tied:
             ranks = np.apply_along_axis(lambda x: add_random_tie(x), -1, dr)
-        ranks = ranks[...,0]  # take obs rank
+        ranks = ranks[..., 0]  # take obs rank
         return ranks
 
     if dim is not None:

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -910,9 +910,7 @@ def rank_histogram(
         if random_for_tied:
             ranks_min = scipy.stats.rankdata(xy, axis=-1, method="min")
             ranks_max = scipy.stats.rankdata(xy, axis=-1, method="max")
-            ranks = np.int32((ranks_max - ranks_min + 1) * np.random.rand(*xy.shape)) + ranks_min
-            # ranks = scipy.stats.rankdata(xy, axis=-1, method="min")
-            # ranks = np.apply_along_axis(lambda x: add_random_tie(x), -1, ranks)
+            ranks = ranks_min + np.int32((ranks_max - ranks_min + 1) * np.random.rand(*xy.shape))
         else:  # no special handling of ties
             ranks = rankdata(xy, axis=-1)
         ranks = ranks[..., 0]  # take obs rank

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -883,6 +883,7 @@ def rank_histogram(
     -----
     See http://www.cawcr.gov.au/projects/verification/
     """
+
     def add_random_tie(ranks):
         """Modify tied ranks by generating random rank."""
         ranks = ranks.copy()

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -929,9 +929,17 @@ def rank_histogram(
     )
 
     bin_edges = np.arange(0.5, len(forecasts[member_dim]) + 2)
-    return histogram(
+    hist = histogram(
         ranks, bins=[bin_edges], bin_names=["rank"], dim=dim, bin_dim_suffix=""
     )
+    if keep_attrs:  # attach by hand
+        hist.attrs.update(observations.attrs)
+        hist.attrs.update(forecasts.attrs)
+        if isinstance(hist, xr.Dataset):
+            for v in hist.data_vars:
+                hist[v].attrs.update(observations[v].attrs)
+                hist[v].attrs.update(forecasts[v].attrs)
+    return hist
 
 
 def discrimination(

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -908,8 +908,11 @@ def rank_histogram(
         first element along the last axes"""
         xy = np.concatenate((x[..., np.newaxis], y), axis=-1)
         if random_for_tied:
-            ranks = scipy.stats.rankdata(xy, axis=-1, method="min")
-            ranks = np.apply_along_axis(lambda x: add_random_tie(x), -1, ranks)
+            ranks_min = scipy.stats.rankdata(xy, axis=-1, method="min")
+            ranks_max = scipy.stats.rankdata(xy, axis=-1, method="max")
+            ranks = np.int32((ranks_max - ranks_min + 1) * np.random.rand(*xy.shape)) + ranks_min
+            # ranks = scipy.stats.rankdata(xy, axis=-1, method="min")
+            # ranks = np.apply_along_axis(lambda x: add_random_tie(x), -1, ranks)
         else:  # no special handling of ties
             ranks = rankdata(xy, axis=-1)
         ranks = ranks[..., 0]  # take obs rank

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -899,9 +899,9 @@ def rank_histogram(
         """Concatenates x and y and returns the rank of the
         first element along the last axes"""
         xy = np.concatenate((x[..., np.newaxis], y), axis=-1)
-        ranks = scipy.stats.rankdata(xy, axis=-1, method='min')
+        ranks = scipy.stats.rankdata(xy, axis=-1, method="min')
         if random_for_tied:
-            ranks = np.apply_along_axis(lambda x: add_random_tie(x), -1, dr)
+            ranks = np.apply_along_axis(lambda x: add_random_tie(x), -1, ranks)
         ranks = ranks[..., 0]  # take obs rank
         return ranks
 

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -851,7 +851,7 @@ def rank_histogram(observations, forecasts, dim=None, member_dim="member", rando
     -------
     rank_histogram : xarray.Dataset or xarray.DataArray
         New object containing the histogram of ranks
-    
+
     Reference
     ---------
     * Hamill, T. M. (2001). Interpretation of Rank Histograms for Verifying
@@ -884,11 +884,11 @@ def rank_histogram(observations, forecasts, dim=None, member_dim="member", rando
         """Modify tied ranks by generating random rank."""
         # add experimental warning linking issue and PR
         u, counts = np.unique(ranks, return_counts=True, axis=-1)
-        for i,count in enumerate(counts):
+        for i, count in enumerate(counts):
             if count > 1:
-                ix = ranks == u[i] # index where to add random # raises warning
+                ix = ranks == u[i]  # index where to add random # raises warning
                 if ranks[ix].shape[0] != 0:
-                    ranks[ix] = ranks[ix] + np.random.randint(0, min(forecasts.member.size + 1, count), len(ranks[ix])) ## increase random rank
+                    ranks[ix] = ranks[ix] + np.random.randint(0, min(forecasts.member.size + 1, count), len(ranks[ix]))  # increase random rank
         return ranks
 
     def _rank_first(x, y):

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -891,18 +891,6 @@ def rank_histogram(
     See http://www.cawcr.gov.au/projects/verification/
     """
 
-    def add_random_tie(ranks):
-        """Modify tied ranks by generating random rank."""
-        ranks = ranks.copy()
-        unique, counts = np.unique(ranks, return_counts=True, axis=-1)
-        for i, count in enumerate(counts):
-            if count > 1:  # duplicate
-                ix = ranks == unique[i]  # index where to add random
-                r = np.arange(counts[i])
-                np.random.shuffle(r)
-                ranks[ix] += r
-        return ranks
-
     def _rank_first(x, y):
         """Concatenates x and y and returns the rank of the
         first element along the last axes"""

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -837,7 +837,7 @@ def rank_histogram(
     dim=None,
     member_dim="member",
     random_for_tied=True,
-    keep_attrs=False,
+    keep_attrs=True,
 ):
     """Returns the rank histogram (Talagrand diagram) along the specified dimensions.
 

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -1,5 +1,6 @@
 import numpy as np
 import properscoring
+import scipy.stats
 import xarray as xr
 
 from .contingency import Contingency, _get_category_bounds
@@ -16,7 +17,6 @@ from .utils import (
     histogram,
     suppress_warnings,
 )
-import scipy.stats
 
 try:
     from bottleneck import nanrankdata as rankdata

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -903,7 +903,7 @@ def rank_histogram(
         if random_for_tied:
             ranks = scipy.stats.rankdata(xy, axis=-1, method="min")
             ranks = np.apply_along_axis(lambda x: add_random_tie(x), -1, ranks)
-        else:
+        else:  # no special handling of ties
             ranks = rankdata(xy, axis=-1)
         ranks = ranks[..., 0]  # take obs rank
         return ranks

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -832,7 +832,7 @@ def rps(
 
 
 def rank_histogram(
-    observations, forecasts, dim=None, member_dim="member", random_for_tied=True
+    observations, forecasts, dim=None, member_dim="member", random_for_tied=True, keep_attrs=False
 ):
     """Returns the rank histogram (Talagrand diagram) along the specified dimensions.
 
@@ -849,6 +849,8 @@ def rank_histogram(
         Name of ensemble member dimension. By default, 'member'.
     random_for_tied : bool
         Whether assign tied ranks random rank, see Hamill 2001
+    keep_attrs : bool, optional
+        Whether to copy attributes from the first argument to the output.
 
     Returns
     -------
@@ -923,6 +925,7 @@ def rank_histogram(
         input_core_dims=[[], [member_dim]],
         dask="parallelized",
         output_dtypes=[int],
+        keep_attrs=keep_attrs,
     )
 
     bin_edges = np.arange(0.5, len(forecasts[member_dim]) + 2)

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -885,10 +885,9 @@ def rank_histogram(observations, forecasts, dim=None, member_dim="member", rando
         # add experimental warning linking issue and PR
         u, counts = np.unique(ranks, return_counts=True, axis=-1)
         for i, count in enumerate(counts):
-            if count > 1:
-                ix = ranks == u[i]  # index where to add random # raises warning
-                if ranks[ix].shape[0] != 0:
-                    ranks[ix] = ranks[ix] + np.random.randint(0, min(forecasts.member.size + 1, count), len(ranks[ix]))  # increase random rank
+            if count > 1:  # duplicate
+                ix = ranks == u[i]  # index where to add random
+                ranks[ix] += np.random.randint(0, min(forecasts.member.size + 1, count), len(ranks[ix]))  # increase random rank
         return ranks
 
     def _rank_first(x, y):

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -910,7 +910,9 @@ def rank_histogram(
         if random_for_tied:
             ranks_min = scipy.stats.rankdata(xy, axis=-1, method="min")
             ranks_max = scipy.stats.rankdata(xy, axis=-1, method="max")
-            ranks = ranks_min + np.int32((ranks_max - ranks_min + 1) * np.random.rand(*xy.shape))
+            ranks = ranks_min + np.int32(
+                (ranks_max - ranks_min + 1) * np.random.rand(*xy.shape)
+            )
         else:  # no special handling of ties
             ranks = rankdata(xy, axis=-1)
         ranks = ranks[..., 0]  # take obs rank

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -853,7 +853,8 @@ def rank_histogram(
     member_dim : str, optional
         Name of ensemble member dimension. By default, 'member'.
     random_for_tied : bool
-        Whether assign tied ranks random rank, see Hamill 2001
+        Whether to randomly generate ranks for tied values so that,
+        on average, tied values result in a flat histogram - see Hamill 2001
     keep_attrs : bool, optional
         Whether to copy attributes from the first argument to the output.
 

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -832,7 +832,12 @@ def rps(
 
 
 def rank_histogram(
-    observations, forecasts, dim=None, member_dim="member", random_for_tied=True, keep_attrs=False
+    observations,
+    forecasts,
+    dim=None,
+    member_dim="member",
+    random_for_tied=True,
+    keep_attrs=False,
 ):
     """Returns the rank histogram (Talagrand diagram) along the specified dimensions.
 

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -351,7 +351,7 @@ def test_rank_histogram_sum(o, f_prob, dim, chunk_bool, input_type, keep_attrs):
         with pytest.raises(ValueError):
             rank_histogram(o, f_prob, dim=dim)
     else:
-        rank_hist = rank_histogram(o, f_prob, dim=dim)
+        rank_hist = rank_histogram(o, f_prob, dim=dim, keep_attrs=keep_attrs)
         if "Dataset" in input_type:
             rank_hist = rank_hist[list(o.data_vars)[0]]
             o = o[list(o.data_vars)[0]]

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -1087,6 +1087,7 @@ def test_brier_score_float_forecast_or_observations(o, f_prob):
     brier_score(o, 0.5)
     brier_score(1, f_prob)
 
+
 def test_rank_hist_tied():
     """Test that rank_histogram handles tied ranks."""
     a = xr.DataArray(np.zeros(100), dims='a')

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -367,9 +367,8 @@ def test_rank_histogram_sum(o, f_prob, dim, chunk_bool, input_type):
 def test_rank_histogram_values(o, f_prob):
     """Test values in extreme cases that observations \
         all smaller/larger than forecasts"""
-    assert rank_histogram(o - 10, f_prob)[0] == o.size  # first is largest bin but not only populated
-    assert rank_histogram(o + 10, f_prob)[-1] == o.size  # last is largest bin but not only populated
-
+    assert rank_histogram(o - 10, f_prob)[0] == o.size
+    assert rank_histogram(o + 10, f_prob)[-1] == o.size
 
 @pytest.mark.parametrize("dim", DIMS)
 @pytest.mark.parametrize("chunk_bool", [True, False])
@@ -1090,8 +1089,8 @@ def test_brier_score_float_forecast_or_observations(o, f_prob):
 
 def test_rank_hist_tied():
     """Test that rank_histogram handles tied ranks."""
-    a = xr.DataArray(np.zeros(100), dims='a')
-    b = xr.DataArray(np.zeros((100, 10)), dims=['a', 'member'])
+    a = xr.DataArray(np.zeros(100), dims="a")
+    b = xr.DataArray(np.zeros((100, 10)), dims=["a", "member"])
     rh = rank_histogram(a, b)
     assert rh.max() != 100
     assert rh.min() > 3

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -343,7 +343,8 @@ def test_brier_score_vs_fair_brier_score(o, f_prob, dim):
 @pytest.mark.parametrize("chunk_bool", [True, False])
 @pytest.mark.parametrize("input_type", ["DataArray", "Dataset", "multidim Dataset"])
 @pytest.mark.parametrize("dim", DIMS)
-def test_rank_histogram_sum(o, f_prob, dim, chunk_bool, input_type):
+@pytest.mark.parametrize("keep_attrs", [True, False])
+def test_rank_histogram_sum(o, f_prob, dim, chunk_bool, input_type, keep_attrs):
     """Test that the number of samples in the rank histogram is correct"""
     o, f_prob = modify_inputs(o, f_prob, input_type, chunk_bool)
     if dim == []:

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -358,7 +358,7 @@ def test_rank_histogram_sum(o, f_prob, dim, chunk_bool, input_type):
         assert_allclose(rank_hist.sum(), o.count())
         # test that returns chunks
         assert_chunk(rank_hist, chunk_bool)
-        # test that attributes are kept # TODO: add
+        # test that attributes are kept # TODO: add 
         # assert_keep_attrs(rank_hist, o, keep_attrs)
         # test that input types equal output types
         assign_type_input_output(rank_hist, o)
@@ -369,6 +369,7 @@ def test_rank_histogram_values(o, f_prob):
         all smaller/larger than forecasts"""
     assert rank_histogram(o - 10, f_prob)[0] == o.size
     assert rank_histogram(o + 10, f_prob)[-1] == o.size
+
 
 @pytest.mark.parametrize("dim", DIMS)
 @pytest.mark.parametrize("chunk_bool", [True, False])

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -367,8 +367,8 @@ def test_rank_histogram_sum(o, f_prob, dim, chunk_bool, input_type):
 def test_rank_histogram_values(o, f_prob):
     """Test values in extreme cases that observations \
         all smaller/larger than forecasts"""
-    assert rank_histogram((o - 10, f_prob)[0] == o.size  # first is largest bin but not only populated
-    assert rank_histogram((o + 10, f_prob)[-1] == o.size  # last is largest bin but not only populated
+    assert rank_histogram(o - 10, f_prob)[0] == o.size  # first is largest bin but not only populated
+    assert rank_histogram(o + 10, f_prob)[-1] == o.size  # last is largest bin but not only populated
 
 
 @pytest.mark.parametrize("dim", DIMS)

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -367,8 +367,8 @@ def test_rank_histogram_sum(o, f_prob, dim, chunk_bool, input_type):
 def test_rank_histogram_values(o, f_prob):
     """Test values in extreme cases that observations \
         all smaller/larger than forecasts"""
-    assert rank_histogram((f_prob.min() - 1) + 0 * o, f_prob)[0] == o.size
-    assert rank_histogram((f_prob.max() + 1) + 0 * o, f_prob)[-1] == o.size
+    assert rank_histogram((f_prob.min() - 1) + 0 * o, f_prob)[0] == o.size  # first is largest bin but not only populated
+    assert rank_histogram((f_prob.max() + 1) + 0 * o, f_prob)[-1] == o.size  # last is largest bin but not only populated
 
 
 @pytest.mark.parametrize("dim", DIMS)

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -358,8 +358,8 @@ def test_rank_histogram_sum(o, f_prob, dim, chunk_bool, input_type):
         assert_allclose(rank_hist.sum(), o.count())
         # test that returns chunks
         assert_chunk(rank_hist, chunk_bool)
-        # test that attributes are kept # TODO: add 
-        # assert_keep_attrs(rank_hist, o, keep_attrs)
+        # test that attributes are kept
+        assert_keep_attrs(rank_hist, o, keep_attrs)
         # test that input types equal output types
         assign_type_input_output(rank_hist, o)
 

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -1094,6 +1094,5 @@ def test_rank_hist_tied():
     a = xr.DataArray(np.zeros(100), dims="a")
     b = xr.DataArray(np.zeros((100, 10)), dims=["a", "member"])
     rh = rank_histogram(a, b)
-    assert rh.max() != 100
     assert rh.min() > 3
     assert rh.max() < 30

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -1086,3 +1086,12 @@ def test_brier_score_float_forecast_or_observations(o, f_prob):
     brier_score(o, f_prob)
     brier_score(o, 0.5)
     brier_score(1, f_prob)
+
+def test_rank_hist_tied():
+    """Test that rank_histogram handles tied ranks."""
+    a = xr.DataArray(np.zeros(100),dims='a')
+    b = xr.DataArray(np.zeros((100,10)),dims=['a','member'])
+    rh = rank_histogram(a, b)
+    assert rh.max() != 100
+    assert rh.min() > 3
+    assert rh.max() < 30

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -367,8 +367,8 @@ def test_rank_histogram_sum(o, f_prob, dim, chunk_bool, input_type):
 def test_rank_histogram_values(o, f_prob):
     """Test values in extreme cases that observations \
         all smaller/larger than forecasts"""
-    assert rank_histogram((f_prob.min() - 1) + 0 * o, f_prob)[0] == o.size  # first is largest bin but not only populated
-    assert rank_histogram((f_prob.max() + 1) + 0 * o, f_prob)[-1] == o.size  # last is largest bin but not only populated
+    assert rank_histogram((f_prob.min() - 10) + 0 * o, f_prob)[0] == o.size  # first is largest bin but not only populated
+    assert rank_histogram((f_prob.max() + 10) + 0 * o, f_prob)[-1] == o.size  # last is largest bin but not only populated
 
 
 @pytest.mark.parametrize("dim", DIMS)

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -1089,8 +1089,8 @@ def test_brier_score_float_forecast_or_observations(o, f_prob):
 
 def test_rank_hist_tied():
     """Test that rank_histogram handles tied ranks."""
-    a = xr.DataArray(np.zeros(100),dims='a')
-    b = xr.DataArray(np.zeros((100,10)),dims=['a','member'])
+    a = xr.DataArray(np.zeros(100), dims='a')
+    b = xr.DataArray(np.zeros((100, 10)), dims=['a', 'member'])
     rh = rank_histogram(a, b)
     assert rh.max() != 100
     assert rh.min() > 3

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -367,8 +367,8 @@ def test_rank_histogram_sum(o, f_prob, dim, chunk_bool, input_type):
 def test_rank_histogram_values(o, f_prob):
     """Test values in extreme cases that observations \
         all smaller/larger than forecasts"""
-    assert rank_histogram((f_prob.min() - 10) + 0 * o, f_prob)[0] == o.size  # first is largest bin but not only populated
-    assert rank_histogram((f_prob.max() + 10) + 0 * o, f_prob)[-1] == o.size  # last is largest bin but not only populated
+    assert rank_histogram((o - 10, f_prob)[0] == o.size  # first is largest bin but not only populated
+    assert rank_histogram((o + 10, f_prob)[-1] == o.size  # last is largest bin but not only populated
 
 
 @pytest.mark.parametrize("dim", DIMS)


### PR DESCRIPTION
# Description

![image](https://user-images.githubusercontent.com/12237157/143320884-f8b4992f-6500-4eb1-88f8-8a57e0d42d81.png)

Closes #335 

## Type of change

-   [x]  New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] pytest

## Checklist (while developing)

-   [x]  I have added docstrings to all new functions.
-   [x]  I have commented my code, particularly in hard-to-understand areas
-   [x]  Tests added for `pytest`, if necessary.

## Pre-Merge Checklist (final steps)

-   [ ]  I have rebased onto main or develop (wherever I am merging) and dealt with any conflicts.
-   [ ]  I have squashed commits to a reasonable amount, and force-pushed the squashed commits.

## References

Hamill, T. M. (2001). Interpretation of Rank Histograms for Verifying Ensemble Forecasts. Monthly Weather Review, 129(3), 550–560. doi: 10/dkkvh3
