### PR TITLE
rm unnecessary package

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,9 +1,9 @@
 # YAML 1.2
 # Metadata for citation of this software according to the CFF format (https://citation-file-format.github.io/)
-cff-version: 1.0.3
+cff-version: 1.2.0
 message: If you use this software, please cite it using these metadata.
 # FIXME title as repository name might not be the best name, please make human readable
-title: 'xarray-contrib/xskillscore: Release v0.0.23'
+title: 'xarray-contrib/xskillscore: Metrics for verifying forecasts '
 doi: 10.5281/zenodo.5173153
 # FIXME splitting of full names is error prone, please check if given/family name are correct
 authors:
@@ -34,8 +34,6 @@ authors:
 - given-names: Taher
   family-names: Chegini
   affiliation: University of Houston
-  https://orcid.org/0000-0002-5430-6000
-version: 0.0.23
-date-released: 2021-08-10
-repository-code: https://github.com/xarray-contrib/xskillscore
+  orcid: https://orcid.org/0000-0002-5430-6000
+url: https://github.com/xarray-contrib/xskillscore
 license: Apache-2.0

--- a/README.rst
+++ b/README.rst
@@ -25,8 +25,8 @@ xskillscore: Metrics for verifying forecasts
 .. image:: https://mybinder.org/badge_logo.svg
    :target: https://mybinder.org/v2/gh/raybellwaves/xskillscore-tutorial/master?urlpath=lab
 
-.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.5173153.svg
-   :target: https://doi.org/10.5281/zenodo.5173153
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.5173152.svg
+   :target: https://doi.org/10.5281/zenodo.5173152
 
 **xskillscore** is an open source project and Python package that provides verification
 metrics of deterministic (and probabilistic from `properscoring`) forecasts with `xarray`.

--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,9 @@ xskillscore: Metrics for verifying forecasts
 .. image:: https://github.com/xarray-contrib/xskillscore/actions/workflows/upstream-dev-ci.yml/badge.svg
    :target: https://github.com/xarray-contrib/xskillscore/actions/workflows/upstream-dev-ci.yml
 
+.. image:: https://results.pre-commit.ci/badge/github/xarray-contrib/xskillscore/main.svg
+   :target: https://results.pre-commit.ci/latest/github/xarray-contrib/xskillscore/main
+
 .. image:: https://img.shields.io/pypi/v/xskillscore.svg
    :target: https://pypi.python.org/pypi/xskillscore/
 

--- a/ci/dev.yml
+++ b/ci/dev.yml
@@ -28,7 +28,6 @@ dependencies:
   - black
   - coveralls
   - doc8
-  - importlib_metadata
   - isort
   - flake8
   - pre-commit

--- a/ci/doc.yml
+++ b/ci/doc.yml
@@ -5,7 +5,6 @@ dependencies:
   - python=3.8
   - bottleneck
   - doc8
-  - importlib_metadata
   - ipykernel
   - ipython
   - nbsphinx

--- a/ci/docs_notebooks.yml
+++ b/ci/docs_notebooks.yml
@@ -13,7 +13,6 @@ dependencies:
   - scipy
   - xarray>=0.16.1
   - xhistogram>=0.3.0
-  - importlib_metadata
   - ipykernel
   - jupyterlab
   - jupyterlab_code_formatter

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,6 +25,9 @@ xskillscore: Metrics for verifying forecasts
 .. image:: https://mybinder.org/badge_logo.svg
    :target: https://mybinder.org/v2/gh/raybellwaves/xskillscore-tutorial/master?urlpath=lab
 
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.5173152.svg
+   :target: https://doi.org/10.5281/zenodo.5173152
+
 Installation
 ============
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,6 +7,9 @@ xskillscore: Metrics for verifying forecasts
 .. image:: https://github.com/xarray-contrib/xskillscore/actions/workflows/upstream-dev-ci.yml/badge.svg
    :target: https://github.com/xarray-contrib/xskillscore/actions/workflows/upstream-dev-ci.yml
 
+.. image:: https://results.pre-commit.ci/badge/github/xarray-contrib/xskillscore/main.svg
+   :target: https://results.pre-commit.ci/latest/github/xarray-contrib/xskillscore/main
+
 .. image:: https://img.shields.io/pypi/v/xskillscore.svg
    :target: https://pypi.python.org/pypi/xskillscore/
 

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,7 +1,9 @@
 version: 2
 
 build:
-    image: latest
+  os: "ubuntu-20.04"
+  tools:
+    python: "mambaforge-4.10"
 
 conda:
     environment: ci/doc.yml

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ EXTRAS_REQUIRE["test"] = [
     "pre-commit",
 ]
 EXTRAS_REQUIRE["docs"] = EXTRAS_REQUIRE["complete"] + [
-    "importlib_metadata",
     "nbsphinx",
     "nbstripout",
     "doc8",


### PR DESCRIPTION
# Description

- use mamba for `rtd` which is faster than `conda`
- make `CITATION.cff` independent of xs version
- link to latest zenodo DOI
- add `pre-commit` badges after registering `pre-commit ci`

## Type of change

-   [x]  refactoring