### PR TITLE
fix `resampling_iterations_idx` on singleton forecast

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ Bug Fixes
 - :py:func:`~xskillscore.rank_histogram` ``random_for_tied=True`` handles tied ranks
   correctly by default. ``random_for_tied=False`` ignores this and retains previous
   behaviour. (:issue:`335`, :pr:`364`) `Aaron Spring`_.
+- Allow singleton dimension in :py:func:`~xskillscore.resample_iterations_idx` as
+  this is allowed in :py:func:`~xskillscore.resample_iterations` also.
+  (:issue:`375`, :pr:`376`) `Aaron Spring`_.
+
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/xskillscore/core/resampling.py
+++ b/xskillscore/core/resampling.py
@@ -227,8 +227,8 @@ def resample_iterations_idx(
     for d in forecast.dims:
         if forecast.sizes["d"] == 1:
             singleton_dims.append(d)
-            forecast = forecast.isel({d:[0]*2})
-        
+            forecast = forecast.isel({d: [0] * 2})
+
     # bug fix when only one iteration
     if iterations == 1:
         forecast_smp = forecast.isel({dim: idx_da.isel(iteration=0, drop=True).values})
@@ -246,5 +246,5 @@ def resample_iterations_idx(
     if dim_coord_set:
         del forecast_smp.coords[dim]
     for d in singleton_dims:
-        forecast_smp = forecast_smp.isel({d:[0]})
+        forecast_smp = forecast_smp.isel({d: [0]})
     return forecast_smp

--- a/xskillscore/core/resampling.py
+++ b/xskillscore/core/resampling.py
@@ -222,6 +222,13 @@ def resample_iterations_idx(
     transpose_kwargs = (
         {"transpose_coords": False} if isinstance(forecast, xr.DataArray) else {}
     )
+    # bug fix if singleton dimension
+    singleton_dims = []
+    for d in forecast.dims:
+        if forecast.sizes["d"] == 1:
+            singleton_dims.append(d)
+            forecast = forecast.isel({d:[0]*2})
+        
     # bug fix when only one iteration
     if iterations == 1:
         forecast_smp = forecast.isel({dim: idx_da.isel(iteration=0, drop=True).values})
@@ -238,4 +245,6 @@ def resample_iterations_idx(
         forecast_smp = forecast_smp.isel({dim: slice(None, dim_max)})
     if dim_coord_set:
         del forecast_smp.coords[dim]
+    for d in singleton_dims:
+        forecast_smp = forecast_smp.isel({d:[0]})
     return forecast_smp

--- a/xskillscore/core/resampling.py
+++ b/xskillscore/core/resampling.py
@@ -225,7 +225,7 @@ def resample_iterations_idx(
     # bug fix if singleton dimension
     singleton_dims = []
     for d in forecast.dims:
-        if forecast.sizes["d"] == 1:
+        if forecast.sizes[d] == 1:
             singleton_dims.append(d)
             forecast = forecast.isel({d: [0] * 2})
 

--- a/xskillscore/tests/test_resampling.py
+++ b/xskillscore/tests/test_resampling.py
@@ -101,18 +101,13 @@ def test_gen_idx_replace(f_prob, replace):
         assert not find_duplicate(actual)
 
 
-@pytest.mark.skip(reason="this is a bug, test fails and should be resolved.")
 def test_resample_iterations_dix_no_squeeze(f_prob):
-    """Test _resample_iteration_idx with singular dimension.
-
-    Currently this fails for dimensions with just a single index as we use `squeeze` in
-    the code and not using squeeze doesnt maintain functionality. This means that
-    ``_resample_iteration_idx`` should not be called on singleton dimension inputs
-    (which is not critical and can be circumvented when using squeeze before.).
-    """
+    """Test _resample_iteration_idx with singular dimension."""
     da = f_prob.expand_dims("test_dim")
     actual = resample_iterations_idx(da, iterations=ITERATIONS)
+    other = resample_iterations(da, iterations=ITERATIONS)
     assert "test_dim" in actual.dims
+    assert actual.coords.to_dataset().equal(actual.coords.to_dataset())
 
 
 @pytest.mark.parametrize("func", resample_iterations_funcs)

--- a/xskillscore/tests/test_resampling.py
+++ b/xskillscore/tests/test_resampling.py
@@ -107,7 +107,7 @@ def test_resample_iterations_dix_no_squeeze(f_prob):
     actual = resample_iterations_idx(da, iterations=ITERATIONS)
     other = resample_iterations(da, iterations=ITERATIONS)
     assert "test_dim" in actual.dims
-    assert actual.coords.to_dataset().equal(other.coords.to_dataset())
+    assert actual.coords.to_dataset().equals(other.coords.to_dataset())
 
 
 @pytest.mark.parametrize("func", resample_iterations_funcs)

--- a/xskillscore/tests/test_resampling.py
+++ b/xskillscore/tests/test_resampling.py
@@ -107,7 +107,7 @@ def test_resample_iterations_dix_no_squeeze(f_prob):
     actual = resample_iterations_idx(da, iterations=ITERATIONS)
     other = resample_iterations(da, iterations=ITERATIONS)
     assert "test_dim" in actual.dims
-    assert actual.coords.to_dataset().equal(actual.coords.to_dataset())
+    assert actual.coords.to_dataset().equal(other.coords.to_dataset())
 
 
 @pytest.mark.parametrize("func", resample_iterations_funcs)


### PR DESCRIPTION
# Description

Closes #375 

## Type of change

Please delete options that are not relevant.

-   [x]  Bug fix (non-breaking change which fixes an issue)

## Checklist (while developing)

-   [ ]  I have commented my code, particularly in hard-to-understand areas
-   [x]  Tests added for `pytest`, if necessary.