### PR TITLE
python3.10 in upstream-dev-ci.yml

### DIFF
--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.10"]
     outputs:
       artifacts_availability: ${{ steps.status.outputs.ARTIFACTS_AVAILABLE }}
     steps:

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -159,7 +159,7 @@ jobs:
             // If no issue is open, create a new issue,
             // else update the body of the existing issue.
             if (result.repository.issues.edges.length === 0) {
-                github.issues.create({
+                github.rest.issues.create({
                     owner: variables.owner,
                     repo: variables.name,
                     body: issue_body,
@@ -167,7 +167,7 @@ jobs:
                     labels: [variables.label]
                 })
             } else {
-                github.issues.update({
+                github.rest.issues.update({
                     owner: variables.owner,
                     repo: variables.name,
                     issue_number: result.repository.issues.edges[0].node.number,

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -33,4 +33,6 @@ python -m pip install \
     git+https://github.com/Unidata/cftime \
     git+https://github.com/pydata/xarray  \
     git+https://github.com/pydata/bottleneck  \
-    git+https://github.com/xgcm/xhistogram
+    git+https://github.com/xgcm/xhistogram \
+    git+https://github.com/numpy/numpy
+

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -10,6 +10,7 @@ conda uninstall -y --force \
     xhistogram \
     xskillscore
 
+
 # to limit the runtime of Upstream CI
 python -m pip install pytest-timeout
 python -m pip install \

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -10,7 +10,6 @@ conda uninstall -y --force \
     xhistogram \
     xskillscore
 
-
 # to limit the runtime of Upstream CI
 python -m pip install pytest-timeout
 python -m pip install \

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -32,5 +32,4 @@ python -m pip install \
     git+https://github.com/Unidata/cftime \
     git+https://github.com/pydata/xarray  \
     git+https://github.com/pydata/bottleneck  \
-    git+https://github.com/xgcm/xhistogram \
-    git+https://github.com/numpy/numpy
+    git+https://github.com/xgcm/xhistogram

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -35,4 +35,3 @@ python -m pip install \
     git+https://github.com/pydata/bottleneck  \
     git+https://github.com/xgcm/xhistogram \
     git+https://github.com/numpy/numpy
-


### PR DESCRIPTION
reporting didnt create issue, see https://github.com/xarray-contrib/xskillscore/runs/6398733878?check_suite_focus=true

EDIT: it did https://github.com/xarray-contrib/xskillscore/issues/383

Use python 3.10 for upstream as xarray does