### PR TITLE
Address DeprecationWarnings and suppress warnings for numpy 1.25+

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,36 +11,36 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
           body: |
             Changes in this Release
           draft: false
+          name: Release ${{ github.ref }}
           prerelease: false
+          tag_name: ${{ github.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
   deploy:
     needs: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build
+          python -m pip install build
       - name: Build and publish
-        run: python -m build
+        run: |
+          python -m build
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -24,8 +24,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 2
-      - uses: xarray-contrib/ci-trigger@v1.1
+      - uses: xarray-contrib/ci-trigger@v1.1.1
         id: detect-trigger
         with:
           keyword: "[test-upstream]"
@@ -57,9 +58,10 @@ jobs:
       - name: setup conda (micromamba)
         uses: mamba-org/setup-micromamba@v1
         with:
+          cache-downloads: true
+          cache-environment: true
           environment-file: ci/dev.yml
           environment-name: xskillscore-dev
-          cache-environment: true
           create-args: >-
             python=${{ matrix.python-version }}
             pytest-reportlog
@@ -110,8 +112,10 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - uses: actions/download-artifact@v2
@@ -127,7 +131,7 @@ jobs:
           wget https://raw.githubusercontent.com/pydata/xarray/master/.github/workflows/parse_logs.py
           python parse_logs.py logs/**/*-log
       - name: Report failures
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/xskillscore_installs.yml
+++ b/.github/workflows/xskillscore_installs.yml
@@ -34,13 +34,13 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .
+        python -m pip install -e .
         python -c "import xskillscore"

--- a/.github/workflows/xskillscore_testing.yml
+++ b/.github/workflows/xskillscore_testing.yml
@@ -37,6 +37,8 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Set up conda
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -72,6 +74,8 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
@@ -102,6 +106,8 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Set up conda
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -113,6 +119,9 @@ jobs:
       - name: Set up conda environment
         run: |
           mamba env update -f ci/docs_notebooks.yml
+      - name: Install xskillscore
+        run: |
+          python -m pip install --no-deps -e .
       - name: Conda info
         run: conda info
       - name: Conda list

--- a/.github/workflows/xskillscore_testing.yml
+++ b/.github/workflows/xskillscore_testing.yml
@@ -15,16 +15,17 @@ jobs:
     outputs:
       triggered: ${{ steps.detect-trigger.outputs.trigger-found }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 2
-      - uses: xarray-contrib/ci-trigger@v1.1
+      - uses: xarray-contrib/ci-trigger@v1.1.1
         id: detect-trigger
         with:
           keyword: "[skip-ci]"
 
   test:  # Runs testing suite on various python versions.
-    name: Test xskillscore, python ${{ matrix.python-version }}
+    name: Test xskillscore (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     needs: detect-ci-trigger
     if: needs.detect-ci-trigger.outputs.triggered == 'false'
@@ -34,26 +35,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3,12", "3.13"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Set up conda
-        uses: conda-incubator/setup-miniconda@v2
+      - name: Set up conda (micromamba)
+        uses: mamba-org/setup-micromamba@v2.0.4
         with:
-          auto-update-conda: true
-          channels: conda-forge
-          mamba-version: '*'
-          activate-environment: xskillscore-minimum-tests
-          python-version: ${{ matrix.python-version }}
-      - name: Set up conda environment
-        run: |
-          mamba env update -f ci/minimum-tests.yml
-      - name: Conda info
-        run: conda info
-      - name: Conda list
-        run: conda list
+          cache-downloads: true
+          cache-environment: true
+          environment-file: ci/minimum-tests.yml
+          create-args: >
+            python=${{ matrix.python-version }}
       - name: Run tests
         run: |
           pytest -n 4 --cov=xskillscore --cov-report=xml --verbose
@@ -72,27 +66,25 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ "3.9", "3.13" ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: conda-incubator/setup-miniconda@v2
+      - name: Set up conda (micromamba)
+        uses: mamba-org/setup-micromamba@v2.0.4
         with:
-          auto-update-conda: true
-          channels: conda-forge
-          mamba-version: "*"
-          activate-environment: xskillscore-minimum-tests
-          python-version: 3.9
-      - name: Set up conda environment
-        run: |
-          mamba env update -f ci/minimum-tests.yml
+          cache-downloads: true
+          cache-environment: true
+          environment-file: ci/minimum-tests.yml
+          create-args: >
+            python=${{ matrix.python-version }}
       - name: Install xskillscore
         run: |
           python -m pip install --no-deps -e .
-      - name: Conda info
-        run: conda info
-      - name: Conda list
-        run: conda list
       - name: Run doctests
         run: |
           python -m pytest --doctest-modules xskillscore --ignore xskillscore/tests
@@ -104,28 +96,24 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
+    strategy:
+      matrix:
+        python-version: [ "3.9" ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Set up conda
-        uses: conda-incubator/setup-miniconda@v2
+      - name: Set up conda (micromamba)
+        uses: mamba-org/setup-micromamba@v2.0.4
         with:
-          auto-update-conda: true
-          channels: conda-forge
-          mamba-version: "*"
-          activate-environment: xskillscore-docs-notebooks
-          python-version: 3.9
-      - name: Set up conda environment
-        run: |
-          mamba env update -f ci/docs_notebooks.yml
+          cache-downloads: true
+          cache-environment: true
+          environment-file: ci/docs_notebooks.yml
+          create-args: >
+            python=${{ matrix.python-version }}
       - name: Install xskillscore
         run: |
           python -m pip install --no-deps -e .
-      - name: Conda info
-        run: conda info
-      - name: Conda list
-        run: conda list
       - name: Test notebooks in docs
         run: |
           pushd docs

--- a/.github/workflows/xskillscore_testing.yml
+++ b/.github/workflows/xskillscore_testing.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3,12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ build
 
 # Mac stuff
 .DS_Store
+
+# JetBrains
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build
 .ipynb_checkpoints/
 .eggs/
 
+# Visual Studio Code
 .vscode
 
 # asv environments
@@ -18,3 +19,6 @@ build
 
 # JetBrains
 .idea
+
+# Documentation
+docs/build/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-docstring-first
@@ -34,7 +34,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.3.5"
+    rev: "v0.11.8"
     hooks:
       - id: ruff
         args: ["--select", "E,F,I001"]
@@ -49,7 +49,7 @@ repos:
         additional_dependencies: ["black==23.10.1"]
 
   - repo: https://github.com/PyCQA/doc8
-    rev: v1.1.1
+    rev: v1.1.2
     hooks:
       - id: doc8
         args:
@@ -62,14 +62,14 @@ repos:
           ]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.9.0"
+    rev: "v1.15.0"
     hooks:
       - id: mypy
         exclude: "asv_bench"
         additional_dependencies: [
             # Type stubs
             types-python-dateutil,
-            types-pkg_resources,
+            types-setuptools,
             types-PyYAML,
             types-pytz,
             typing-extensions,
@@ -78,7 +78,7 @@ repos:
           ]
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.28.1
+    rev: 0.33.0
     hooks:
       - id: check-github-workflows
       - id: check-readthedocs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: "ubuntu-22.04"
+  os: "ubuntu-24.04"
   tools:
-    python: "mambaforge-22.9"
+    python: "mambaforge-23.11"
   jobs:
     post_checkout:
       - (git --no-pager log --pretty="tformat:%s" -1 | grep -vqF "[skip-rtd]") || exit 183
@@ -18,3 +18,8 @@ sphinx:
   fail_on_warning: false
 
 formats: []
+
+python:
+  install:
+    - method: pip
+      path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,7 +15,7 @@ conda:
   environment: ci/doc.yml
 
 sphinx:
-  configuration: .readthedocs.yml
+  configuration: docs/source/conf.py
   fail_on_warning: false
 
 formats: []

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,6 +15,7 @@ conda:
   environment: ci/doc.yml
 
 sphinx:
+  configuration: .readthedocs.yml
   fail_on_warning: false
 
 formats: []

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,13 +2,30 @@
 Changelog History
 =================
 
+
+xskillscore v0.0.27 (unreleased)
+--------------------------------
+
+Bug Fixes
+~~~~~~~~~
+- Updated and corrected the build configurations in the GitHub workflows so that the correct
+  Python is used when running automated build tests. (:pr:`426`) `Trevor James Smith`_
+
+Internal Changes
+~~~~~~~~~~~~~~~~
+- Adapted code base for modern `numpy` and `xarray`. (:pr:`426`) `Trevor James Smith`_
+- Removed :py:func:`xskillscore.core.utils.suppress_warnings` in lieu of
+  :py:func:`warnings.filterwarnings`. (:pr:`426`) `Trevor James Smith`_
+- The minimum supported versions for several dependencies have been
+  updated. (:pr:`426`) `Trevor James Smith`_
+
+
 xskillscore v0.0.26 (2024-03-10)
 --------------------------------
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
 - Fix build `Ray Bell`_.
-
 
 xskillscore v0.0.25 (2024-03-10)
 --------------------------------
@@ -21,7 +38,6 @@ Bug Fixes
 - Allow singleton dimension in :py:func:`~xskillscore.resample_iterations_idx` as
   this is allowed in :py:func:`~xskillscore.resample_iterations` also.
   (:issue:`375`, :pr:`376`) `Aaron Spring`_.
-
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
@@ -47,7 +63,6 @@ Features
 ~~~~~~~~
 - :py:func:`~xskillscore.multipletests` controlling the false discovery rate for
   multiple hypothesis tests. (:issue:`365`, :pr:`370`) `Aaron Spring`_.
-
 
 Bug Fixes
 ~~~~~~~~~
@@ -76,7 +91,6 @@ xskillscore v0.0.21 (2021-06-13)
 
 - Allow ``float`` or ``integer`` forecasts in :py:func:`~xskillscore.brier_score`
   (:issue:`285`, :pr:`342`) `Aaron Spring`_
-
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
@@ -324,13 +338,11 @@ Deprecations
 ~~~~~~~~~~~~
 - ``mad`` no longer works and is replaced by ``median_absolute_error``. `Riley X. Brady`_
 
-
 Bug Fixes
 ~~~~~~~~~
 - ``skipna`` for ``pearson_r`` and ``spearman_r`` and their p-values now reports
   accurate results when there are pairwise nans (i.e., nans that occur in different
   indices in ``a`` and ``b``) `Riley X. Brady`_
-
 
 Testing
 ~~~~~~~
@@ -348,4 +360,5 @@ Testing
 .. _`Riley X. Brady`: https://github.com/bradyrx
 .. _`Ray Bell`: https://github.com/raybellwaves
 .. _`Taher Chegini`: https://github.com/cheginit
+.. _`Trevor James Smith`: https://github.com/Zeitsperre
 .. _`Zachary Blackwood`: https://github.com/blackary

--- a/ci/dev.yml
+++ b/ci/dev.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python >= 3.9,<3.12
+  - pip >= 23.0
   # Documentation
   - matplotlib-base
   - nbsphinx
@@ -10,15 +11,14 @@ dependencies:
   - sphinx
   - sphinx_rtd_theme
   - sphinx-autosummary-accessors
-  - sphinxcontrib-napoleon
   # IDE
   - jupyterlab
   # Numerics
   - bottleneck
   - cftime
   - dask-core
-  - numba>=0.52
-  - numpy
+  - numba >=0.57
+  - numpy >=1.25
   - properscoring
   - scikit-learn
   - scipy
@@ -33,7 +33,8 @@ dependencies:
   - pre-commit
   - pytest
   - pytest-cov
-  - pytest-xdist
   - pytest-sugar
+  - pytest-timeout
+  - pytest-xdist
   - mypy
   - ruff

--- a/ci/dev.yml
+++ b/ci/dev.yml
@@ -2,29 +2,29 @@ name: xskillscore-dev
 channels:
   - conda-forge
 dependencies:
-  - python >= 3.9,<3.12
+  - python >= 3.9,<3.14
   - pip >= 23.0
   # Documentation
   - matplotlib-base
   - nbsphinx
   - nbstripout
-  - sphinx
-  - sphinx_rtd_theme
+  - sphinx >=6.0.0
+  - sphinx_rtd_theme >=1.0
   - sphinx-autosummary-accessors
   # IDE
   - jupyterlab
   # Numerics
   - bottleneck
   - cftime
-  - dask-core
+  - dask-core >=2023.4.0
   - numba >=0.57
-  - numpy >=1.25
+  - numpy >=1.24
   - properscoring
   - scikit-learn
-  - scipy
+  - scipy >=1.10.0
   - statsmodels
-  - xarray>=0.16.1
-  - xhistogram>=0.3.0
+  - xarray>=2023.4.0
+  - xhistogram>=0.3.2
   # Package Management
   - asv
   - build

--- a/ci/doc.yml
+++ b/ci/doc.yml
@@ -2,24 +2,24 @@ name: xskillscore-docs
 channels:
   - conda-forge
 dependencies:
-  - python >=3.9
+  - python >=3.9,<3.14
   - pip >=23.0
   - bottleneck
   - cftime
-  - dask-core
+  - dask-core >=2023.4.0
   - doc8
   - ipykernel
   - ipython
   - matplotlib-base
   - nbsphinx
-  - numpy >=1.25
+  - numpy >=1.24
   - properscoring
   - scikit-learn
-  - scipy
-  - sphinx !=4.4.0
+  - scipy >=1.10
+  - sphinx >=6.0.0
   - sphinx_rtd_theme >=1.0
   - sphinx-autosummary-accessors
   - sphinx-copybutton
   - statsmodels
-  - xarray>=0.16.1
-  - xhistogram>=0.3.0
+  - xarray >=2023.4.0
+  - xhistogram>=0.3.2

--- a/ci/doc.yml
+++ b/ci/doc.yml
@@ -23,5 +23,3 @@ dependencies:
   - statsmodels
   - xarray>=0.16.1
   - xhistogram>=0.3.0
-  - pip:
-      - -e ..

--- a/ci/doc.yml
+++ b/ci/doc.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python >=3.9
+  - pip >=23.0
   - bottleneck
   - cftime
   - dask-core
@@ -11,13 +12,12 @@ dependencies:
   - ipython
   - matplotlib-base
   - nbsphinx
-  - numpy
-  - pip
+  - numpy >=1.25
   - properscoring
   - scikit-learn
   - scipy
-  - sphinx!=4.4.0
-  - sphinx_rtd_theme
+  - sphinx !=4.4.0
+  - sphinx_rtd_theme >=1.0
   - sphinx-autosummary-accessors
   - sphinx-copybutton
   - statsmodels

--- a/ci/docs_notebooks.yml
+++ b/ci/docs_notebooks.yml
@@ -3,12 +3,14 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
+  - python >=3.9
+  - pip >=23.0
   - bottleneck
   - cftime
   - dask-core
   - doc8
-  - numba>=0.52
-  - numpy
+  - numba >=0.57
+  - numpy >=1.25
   - properscoring
   - ipykernel
   - jupyterlab
@@ -16,14 +18,12 @@ dependencies:
   - matplotlib-base
   - nbsphinx
   - nbstripout
-  - pip
   - pre-commit
   - scikit-learn
   - scipy
   - sphinx
   - sphinx-autosummary-accessors
   - sphinx_rtd_theme
-  - sphinxcontrib-napoleon
   - statsmodels
   - xarray>=0.16.1
   - xhistogram>=0.3.0

--- a/ci/docs_notebooks.yml
+++ b/ci/docs_notebooks.yml
@@ -3,14 +3,14 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python >=3.9
+  - python >=3.9,<3.14
   - pip >=23.0
   - bottleneck
   - cftime
-  - dask-core
+  - dask-core >=2023.4.0
   - doc8
   - numba >=0.57
-  - numpy >=1.25
+  - numpy >=1.24
   - properscoring
   - ipykernel
   - jupyterlab
@@ -20,10 +20,10 @@ dependencies:
   - nbstripout
   - pre-commit
   - scikit-learn
-  - scipy
-  - sphinx
+  - scipy >=1.10
+  - sphinx >=6.0.0
   - sphinx-autosummary-accessors
-  - sphinx_rtd_theme
+  - sphinx_rtd_theme >=1.0
   - statsmodels
-  - xarray>=0.16.1
-  - xhistogram>=0.3.0
+  - xarray >=2023.4.0
+  - xhistogram >=0.3.2

--- a/ci/docs_notebooks.yml
+++ b/ci/docs_notebooks.yml
@@ -27,6 +27,3 @@ dependencies:
   - statsmodels
   - xarray>=0.16.1
   - xhistogram>=0.3.0
-  - pip:
-      # Install latest version of xskillscore.
-      - -e ..

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -21,7 +21,6 @@ python -m pip install \
     scipy \
     matplotlib \
     pandas
-python -m pip install pytest-timeout
 python -m pip install \
     --no-deps \
     --upgrade \

--- a/ci/minimum-tests.yml
+++ b/ci/minimum-tests.yml
@@ -20,5 +20,3 @@ dependencies:
   - statsmodels
   - xarray>=0.16.1
   - xhistogram>=0.3.0
-  - pip:
-      - -e ..

--- a/ci/minimum-tests.yml
+++ b/ci/minimum-tests.yml
@@ -2,16 +2,18 @@ name: xskillscore-minimum-tests
 channels:
   - conda-forge
 dependencies:
+  - python >=3.9
+  - pip >=23.0
   - bottleneck
   - cftime
   - coveralls
   - dask-core
   - matplotlib-base
-  - numpy
-  - pip
+  - numpy >=1.25
   - properscoring
   - pytest
   - pytest-cov
+  - pytest-timeout
   - pytest-xdist
   - scikit-learn
   - scipy

--- a/ci/minimum-tests.yml
+++ b/ci/minimum-tests.yml
@@ -2,21 +2,21 @@ name: xskillscore-minimum-tests
 channels:
   - conda-forge
 dependencies:
-  - python >=3.9
+  - python >=3.9,<3.14
   - pip >=23.0
   - bottleneck
   - cftime
   - coveralls
-  - dask-core
+  - dask-core >=2023.4.0
   - matplotlib-base
-  - numpy >=1.25
+  - numpy >=1.24
   - properscoring
   - pytest
   - pytest-cov
   - pytest-timeout
   - pytest-xdist
   - scikit-learn
-  - scipy
+  - scipy >=1.10
   - statsmodels
-  - xarray>=0.16.1
-  - xhistogram>=0.3.0
+  - xarray>=2023.4.0
+  - xhistogram>=0.3.2

--- a/conftest.py
+++ b/conftest.py
@@ -21,7 +21,7 @@ def add_standard_imports(doctest_namespace):
 
 @pytest.fixture
 def times():
-    return xr.cftime_range(start="2000", periods=PERIODS, freq="D")
+    return xr.date_range(start="2000", periods=PERIODS, freq="D", use_cftime=True)
 
 
 @pytest.fixture
@@ -165,7 +165,7 @@ def b_1d(b):
 
 @pytest.fixture
 def a_1d_fixed_nan():
-    time = xr.cftime_range("2000-01-01", "2000-01-03", freq="D")
+    time = xr.date_range("2000-01-01", "2000-01-03", freq="D", use_cftime=True)
     return xr.DataArray([3, np.nan, 5], dims=["time"], coords=[time])
 
 
@@ -211,7 +211,7 @@ def weights_lonlat(a):
 
 @pytest.fixture
 def weights_time():
-    time = xr.cftime_range("2000-01-01", "2000-01-03", freq="D")
+    time = xr.date_range("2000-01-01", "2000-01-03", freq="D", use_cftime=True)
     return xr.DataArray([1, 2, 3], dims=["time"], coords=[time])
 
 
@@ -232,7 +232,7 @@ def category_edges():
 @pytest.fixture
 def forecast_3d_int():
     """Random integer 3D forecast used for testing Contingency."""
-    times = xr.cftime_range(start="2000", freq="D", periods=10)
+    times = xr.date_range(start="2000", freq="D", periods=10, use_cftime=True)
     lats = np.arange(4)
     lons = np.arange(5)
     data = np.random.randint(0, 10, size=(len(times), len(lats), len(lons)))

--- a/docs/source/api/xskillscore.Contingency.accuracy.rst
+++ b/docs/source/api/xskillscore.Contingency.accuracy.rst
@@ -1,4 +1,4 @@
-xskillscore.Contingency.accuracy
+﻿xskillscore.Contingency.accuracy
 ================================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.Contingency.bias_score.rst
+++ b/docs/source/api/xskillscore.Contingency.bias_score.rst
@@ -1,4 +1,4 @@
-xskillscore.Contingency.bias\_score
+﻿xskillscore.Contingency.bias\_score
 ===================================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.Contingency.correct_negatives.rst
+++ b/docs/source/api/xskillscore.Contingency.correct_negatives.rst
@@ -1,4 +1,4 @@
-xskillscore.Contingency.correct\_negatives
+﻿xskillscore.Contingency.correct\_negatives
 ==========================================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.Contingency.equit_threat_score.rst
+++ b/docs/source/api/xskillscore.Contingency.equit_threat_score.rst
@@ -1,4 +1,4 @@
-xskillscore.Contingency.equit\_threat\_score
+﻿xskillscore.Contingency.equit\_threat\_score
 ============================================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.Contingency.false_alarm_rate.rst
+++ b/docs/source/api/xskillscore.Contingency.false_alarm_rate.rst
@@ -1,4 +1,4 @@
-xskillscore.Contingency.false\_alarm\_rate
+﻿xskillscore.Contingency.false\_alarm\_rate
 ==========================================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.Contingency.false_alarm_ratio.rst
+++ b/docs/source/api/xskillscore.Contingency.false_alarm_ratio.rst
@@ -1,4 +1,4 @@
-xskillscore.Contingency.false\_alarm\_ratio
+﻿xskillscore.Contingency.false\_alarm\_ratio
 ===========================================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.Contingency.false_alarms.rst
+++ b/docs/source/api/xskillscore.Contingency.false_alarms.rst
@@ -1,4 +1,4 @@
-xskillscore.Contingency.false\_alarms
+﻿xskillscore.Contingency.false\_alarms
 =====================================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.Contingency.gerrity_score.rst
+++ b/docs/source/api/xskillscore.Contingency.gerrity_score.rst
@@ -1,4 +1,4 @@
-xskillscore.Contingency.gerrity\_score
+﻿xskillscore.Contingency.gerrity\_score
 ======================================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.Contingency.heidke_score.rst
+++ b/docs/source/api/xskillscore.Contingency.heidke_score.rst
@@ -1,4 +1,4 @@
-xskillscore.Contingency.heidke\_score
+﻿xskillscore.Contingency.heidke\_score
 =====================================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.Contingency.hit_rate.rst
+++ b/docs/source/api/xskillscore.Contingency.hit_rate.rst
@@ -1,4 +1,4 @@
-xskillscore.Contingency.hit\_rate
+﻿xskillscore.Contingency.hit\_rate
 =================================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.Contingency.hits.rst
+++ b/docs/source/api/xskillscore.Contingency.hits.rst
@@ -1,4 +1,4 @@
-xskillscore.Contingency.hits
+﻿xskillscore.Contingency.hits
 ============================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.Contingency.misses.rst
+++ b/docs/source/api/xskillscore.Contingency.misses.rst
@@ -1,4 +1,4 @@
-xskillscore.Contingency.misses
+﻿xskillscore.Contingency.misses
 ==============================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.Contingency.odds_ratio.rst
+++ b/docs/source/api/xskillscore.Contingency.odds_ratio.rst
@@ -1,4 +1,4 @@
-xskillscore.Contingency.odds\_ratio
+﻿xskillscore.Contingency.odds\_ratio
 ===================================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.Contingency.odds_ratio_skill_score.rst
+++ b/docs/source/api/xskillscore.Contingency.odds_ratio_skill_score.rst
@@ -1,4 +1,4 @@
-xskillscore.Contingency.odds\_ratio\_skill\_score
+﻿xskillscore.Contingency.odds\_ratio\_skill\_score
 =================================================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.Contingency.peirce_score.rst
+++ b/docs/source/api/xskillscore.Contingency.peirce_score.rst
@@ -1,4 +1,4 @@
-xskillscore.Contingency.peirce\_score
+﻿xskillscore.Contingency.peirce\_score
 =====================================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.Contingency.rst
+++ b/docs/source/api/xskillscore.Contingency.rst
@@ -1,4 +1,4 @@
-xskillscore.Contingency
+﻿xskillscore.Contingency
 =======================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.Contingency.success_ratio.rst
+++ b/docs/source/api/xskillscore.Contingency.success_ratio.rst
@@ -1,4 +1,4 @@
-xskillscore.Contingency.success\_ratio
+﻿xskillscore.Contingency.success\_ratio
 ======================================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.Contingency.table.rst
+++ b/docs/source/api/xskillscore.Contingency.table.rst
@@ -1,4 +1,4 @@
-xskillscore.Contingency.table
+﻿xskillscore.Contingency.table
 =============================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.Contingency.threat_score.rst
+++ b/docs/source/api/xskillscore.Contingency.threat_score.rst
@@ -1,4 +1,4 @@
-xskillscore.Contingency.threat\_score
+﻿xskillscore.Contingency.threat\_score
 =====================================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.brier_score.rst
+++ b/docs/source/api/xskillscore.brier_score.rst
@@ -1,4 +1,4 @@
-xskillscore.brier\_score
+﻿xskillscore.brier\_score
 ========================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.core.resampling.resample_iterations.rst
+++ b/docs/source/api/xskillscore.core.resampling.resample_iterations.rst
@@ -1,4 +1,4 @@
-xskillscore.core.resampling.resample\_iterations
+﻿xskillscore.core.resampling.resample\_iterations
 ================================================
 
 .. currentmodule:: xskillscore.core.resampling

--- a/docs/source/api/xskillscore.core.resampling.resample_iterations_idx.rst
+++ b/docs/source/api/xskillscore.core.resampling.resample_iterations_idx.rst
@@ -1,4 +1,4 @@
-xskillscore.core.resampling.resample\_iterations\_idx
+﻿xskillscore.core.resampling.resample\_iterations\_idx
 =====================================================
 
 .. currentmodule:: xskillscore.core.resampling

--- a/docs/source/api/xskillscore.crps_ensemble.rst
+++ b/docs/source/api/xskillscore.crps_ensemble.rst
@@ -1,4 +1,4 @@
-xskillscore.crps\_ensemble
+﻿xskillscore.crps\_ensemble
 ==========================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.crps_gaussian.rst
+++ b/docs/source/api/xskillscore.crps_gaussian.rst
@@ -1,4 +1,4 @@
-xskillscore.crps\_gaussian
+﻿xskillscore.crps\_gaussian
 ==========================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.crps_quadrature.rst
+++ b/docs/source/api/xskillscore.crps_quadrature.rst
@@ -1,4 +1,4 @@
-xskillscore.crps\_quadrature
+﻿xskillscore.crps\_quadrature
 ============================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.discrimination.rst
+++ b/docs/source/api/xskillscore.discrimination.rst
@@ -1,4 +1,4 @@
-xskillscore.discrimination
+﻿xskillscore.discrimination
 ==========================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.effective_sample_size.rst
+++ b/docs/source/api/xskillscore.effective_sample_size.rst
@@ -1,4 +1,4 @@
-xskillscore.effective\_sample\_size
+﻿xskillscore.effective\_sample\_size
 ===================================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.halfwidth_ci_test.rst
+++ b/docs/source/api/xskillscore.halfwidth_ci_test.rst
@@ -1,4 +1,4 @@
-xskillscore.halfwidth\_ci\_test
+﻿xskillscore.halfwidth\_ci\_test
 ===============================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.linslope.rst
+++ b/docs/source/api/xskillscore.linslope.rst
@@ -1,4 +1,4 @@
-xskillscore.linslope
+﻿xskillscore.linslope
 ====================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.mae.rst
+++ b/docs/source/api/xskillscore.mae.rst
@@ -1,4 +1,4 @@
-xskillscore.mae
+﻿xskillscore.mae
 ===============
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.mape.rst
+++ b/docs/source/api/xskillscore.mape.rst
@@ -1,4 +1,4 @@
-xskillscore.mape
+﻿xskillscore.mape
 ================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.me.rst
+++ b/docs/source/api/xskillscore.me.rst
@@ -1,4 +1,4 @@
-xskillscore.me
+﻿xskillscore.me
 ==============
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.median_absolute_error.rst
+++ b/docs/source/api/xskillscore.median_absolute_error.rst
@@ -1,4 +1,4 @@
-xskillscore.median\_absolute\_error
+﻿xskillscore.median\_absolute\_error
 ===================================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.mse.rst
+++ b/docs/source/api/xskillscore.mse.rst
@@ -1,4 +1,4 @@
-xskillscore.mse
+﻿xskillscore.mse
 ===============
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.pearson_r.rst
+++ b/docs/source/api/xskillscore.pearson_r.rst
@@ -1,4 +1,4 @@
-xskillscore.pearson\_r
+﻿xskillscore.pearson\_r
 ======================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.pearson_r_eff_p_value.rst
+++ b/docs/source/api/xskillscore.pearson_r_eff_p_value.rst
@@ -1,4 +1,4 @@
-xskillscore.pearson\_r\_eff\_p\_value
+﻿xskillscore.pearson\_r\_eff\_p\_value
 =====================================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.pearson_r_p_value.rst
+++ b/docs/source/api/xskillscore.pearson_r_p_value.rst
@@ -1,4 +1,4 @@
-xskillscore.pearson\_r\_p\_value
+﻿xskillscore.pearson\_r\_p\_value
 ================================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.r2.rst
+++ b/docs/source/api/xskillscore.r2.rst
@@ -1,4 +1,4 @@
-xskillscore.r2
+﻿xskillscore.r2
 ==============
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.rank_histogram.rst
+++ b/docs/source/api/xskillscore.rank_histogram.rst
@@ -1,4 +1,4 @@
-xskillscore.rank\_histogram
+﻿xskillscore.rank\_histogram
 ===========================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.reliability.rst
+++ b/docs/source/api/xskillscore.reliability.rst
@@ -1,4 +1,4 @@
-xskillscore.reliability
+﻿xskillscore.reliability
 =======================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.rmse.rst
+++ b/docs/source/api/xskillscore.rmse.rst
@@ -1,4 +1,4 @@
-xskillscore.rmse
+﻿xskillscore.rmse
 ================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.roc.rst
+++ b/docs/source/api/xskillscore.roc.rst
@@ -1,4 +1,4 @@
-xskillscore.roc
+﻿xskillscore.roc
 ===============
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.rps.rst
+++ b/docs/source/api/xskillscore.rps.rst
@@ -1,4 +1,4 @@
-xskillscore.rps
+﻿xskillscore.rps
 ===============
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.sign_test.rst
+++ b/docs/source/api/xskillscore.sign_test.rst
@@ -1,4 +1,4 @@
-xskillscore.sign\_test
+﻿xskillscore.sign\_test
 ======================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.smape.rst
+++ b/docs/source/api/xskillscore.smape.rst
@@ -1,4 +1,4 @@
-xskillscore.smape
+﻿xskillscore.smape
 =================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.spearman_r.rst
+++ b/docs/source/api/xskillscore.spearman_r.rst
@@ -1,4 +1,4 @@
-xskillscore.spearman\_r
+﻿xskillscore.spearman\_r
 =======================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.spearman_r_eff_p_value.rst
+++ b/docs/source/api/xskillscore.spearman_r_eff_p_value.rst
@@ -1,4 +1,4 @@
-xskillscore.spearman\_r\_eff\_p\_value
+﻿xskillscore.spearman\_r\_eff\_p\_value
 ======================================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.spearman_r_p_value.rst
+++ b/docs/source/api/xskillscore.spearman_r_p_value.rst
@@ -1,4 +1,4 @@
-xskillscore.spearman\_r\_p\_value
+﻿xskillscore.spearman\_r\_p\_value
 =================================
 
 .. currentmodule:: xskillscore

--- a/docs/source/api/xskillscore.threshold_brier_score.rst
+++ b/docs/source/api/xskillscore.threshold_brier_score.rst
@@ -1,4 +1,4 @@
-xskillscore.threshold\_brier\_score
+﻿xskillscore.threshold\_brier\_score
 ===================================
 
 .. currentmodule:: xskillscore

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,7 +65,7 @@ numpydoc_show_class_members = False
 templates_path = ["_templates", sphinx_autosummary_accessors.templates_path]
 
 # The suffix of source filenames.
-source_suffix = ".rst"
+source_suffix = {".rst": "restructuredtext"}
 
 # The master toctree document.
 master_doc = "index"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,8 +33,8 @@ print("xskillscore: %s, %s" % (xskillscore.__version__, xskillscore.__file__))
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
-    "sphinx.ext.intersphinx",
     "sphinx.ext.extlinks",
+    "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "IPython.sphinxext.ipython_directive",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,13 @@ build-backend = "setuptools.build_meta"
 name = "xskillscore"
 version = "0.0.26"
 dependencies = [
-  "dask[array]",
-  "numpy >=1.25",
+  "dask[array] >=2023.4.0",
+  "numpy >=1.24",
   "properscoring",
-  "scipy",
+  "scipy >=1.10",
   "statsmodels",
-  "xarray>=0.16.1",
-  "xhistogram>=0.3.0",
+  "xarray>=2023.4.0",
+  "xhistogram>=0.3.2",
 ]
 authors = [{name = "Ray Bell", email = "rayjohnbell0@gmail.com"}]
 description = "Metrics for verifying forecasts"
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Atmospheric Science",
     "Topic :: Scientific/Engineering :: Mathematics",
 ]
@@ -57,11 +58,10 @@ complete = [
     "nbstripout",
     "properscoring",
     "pytest-sugar",
-    "sphinx !=4.4.0",
+    "sphinx >=6.0.0",
     "sphinx-autosummary-accessors",
     "sphinx-copybutton",
     "sphinx-rtd-theme>=1.0",
-    "sphinxcontrib-napoleon",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,11 @@ test = [
 complete = [
     "xskillscore[test]",
     "doc8",
+    "ipykernel",
+    "ipython",
     "nbsphinx",
     "nbstripout",
+    "properscoring",
     "pytest-sugar",
     "sphinx !=4.4.0",
     "sphinx-autosummary-accessors",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "xskillscore"
 version = "0.0.26"
 dependencies = [
   "dask[array]",
-  "numpy",
+  "numpy >=1.25",
   "properscoring",
   "scipy",
   "statsmodels",
@@ -26,6 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Atmospheric Science",
     "Topic :: Scientific/Engineering :: Mathematics",
 ]
@@ -39,28 +40,21 @@ test = [
     "bottleneck",
     "cftime",
     "matplotlib",
-    "numba>=0.52",
+    "numba >=0.57",
     "pre-commit",
     "pytest",
     "pytest-cov",
+    "pytest-timeout",
     "pytest-xdist",
     "scikit-learn",
 ]
 complete = [
-    "bottleneck",
-    "cftime",
+    "xskillscore[test]",
     "doc8",
-    "matplotlib",
     "nbsphinx",
     "nbstripout",
-    "numba>=0.52",
-    "pre-commit",
-    "pytest",
-    "pytest-cov",
-    "pytest-xdist",
     "pytest-sugar",
-    "scikit-learn",
-    "sphinx",
+    "sphinx !=4.4.0",
     "sphinx-autosummary-accessors",
     "sphinx-copybutton",
     "sphinx-rtd-theme>=1.0",
@@ -86,6 +80,8 @@ testpaths = ["xskillscore/tests"]
 addopts = "--color=yes --verbose"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "flaky: marks tests as flaky (deselect with '-m \"not flaky\"')",
+    "network: marks tests that require network access (deselect with '-m \"not network\"')",
 ]
 
 [tool.doc8]

--- a/xskillscore/core/deterministic.py
+++ b/xskillscore/core/deterministic.py
@@ -1210,12 +1210,12 @@ def mape(
     skipna: bool = False,
     keep_attrs: bool = False,
 ) -> XArray:
-    """Mean Absolute Percentage Error.
+    r"""Mean Absolute Percentage Error.
 
     .. math::
-        \\mathrm{MAPE} = \\frac{1}{n} \\sum_{i=1}^{n}
-                         \\frac{\\vert a_{i} - b_{i} \\vert}
-                               {max(\epsilon, \\vert a_{i} \\vert)}
+        \mathrm{MAPE} = \frac{1}{n} \sum_{i=1}^{n}
+                         \frac{\vert a_{i} - b_{i} \vert}
+                               {max(\epsilon, \vert a_{i} \vert)}
 
     .. note::
         The percent error is calculated in reference to ``a``. Percent

--- a/xskillscore/core/deterministic.py
+++ b/xskillscore/core/deterministic.py
@@ -53,13 +53,13 @@ __all__ = [
 
 def _determine_input_core_dims(
     dim: str | List[str], weights: XArray | None
-) -> List[object]:
+) -> List[List[str]]:
     """
     Determine input_core_dims based on type of dim and weights.
 
     Parameters
     ----------
-    dim : str, list
+    dim : str or list of str
         The dimension(s) to apply the metric along.
     weights : xarray.Dataset or xarray.DataArray or None
         Weights matching dimensions of ``dim`` to apply during the function.

--- a/xskillscore/core/np_probabilistic.py
+++ b/xskillscore/core/np_probabilistic.py
@@ -1,6 +1,6 @@
-import numpy as np
+import warnings
 
-from .utils import suppress_warnings
+import numpy as np
 
 __all__ = ["_reliability"]
 
@@ -35,12 +35,10 @@ def _reliability(o, f, bin_edges):
             r.append(N_o_f_in_bin / N_f_in_bin)
             N.append(N_f_in_bin)
         else:
-            with suppress_warnings("invalid value encountered in true_divide"):
-                with suppress_warnings("invalid value encountered in long_scalars"):
-                    with suppress_warnings("invalid value encountered in scalar divide"):
-                        with suppress_warnings("invalid value encountered in divide"):
-                            r[..., i] = N_o_f_in_bin / N_f_in_bin
-                            N[..., i] = N_f_in_bin
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", RuntimeWarning)
+                r[..., i] = N_o_f_in_bin / N_f_in_bin
+                N[..., i] = N_f_in_bin
 
     if is_dask_array:
         import dask.array as da

--- a/xskillscore/core/np_probabilistic.py
+++ b/xskillscore/core/np_probabilistic.py
@@ -37,8 +37,10 @@ def _reliability(o, f, bin_edges):
         else:
             with suppress_warnings("invalid value encountered in true_divide"):
                 with suppress_warnings("invalid value encountered in long_scalars"):
-                    r[..., i] = N_o_f_in_bin / N_f_in_bin
-                    N[..., i] = N_f_in_bin
+                    with suppress_warnings("invalid value encountered in scalar divide"):
+                        with suppress_warnings("invalid value encountered in divide"):
+                            r[..., i] = N_o_f_in_bin / N_f_in_bin
+                            N[..., i] = N_f_in_bin
 
     if is_dask_array:
         import dask.array as da

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import Callable, List, Literal, Optional, Tuple
 
 import numpy as np
@@ -20,7 +21,6 @@ from .utils import (
     _preprocess_dims,
     _stack_input_if_needed,
     histogram,
-    suppress_warnings,
 )
 
 try:
@@ -524,9 +524,9 @@ def _assign_rps_category_bounds(
             }
         )
         res[f"{name}_category_edge"] = (
-            f"[-np.inf, {edges[bin_dim].isel({bin_dim:0}).values}), "
+            f"[-np.inf, {edges[bin_dim].isel({bin_dim: 0}).values}), "
             f"{str(res[f'{name}_category_edge'].values)[:-1]}), "
-            f"[{edges[bin_dim].isel({bin_dim:-1}).values}, np.inf]"
+            f"[{edges[bin_dim].isel({bin_dim: -1}).values}, np.inf]"
         )
     return res
 
@@ -1178,11 +1178,11 @@ def _drop_intermediate(fpr, tpr):
     optimal_idxs["probability_bin"] = np.arange(optimal_idxs.probability_bin.size)
     if isinstance(optimal_idxs, xr.Dataset):
         optimal_idxs = optimal_idxs.to_array()
-    with suppress_warnings("invalid value encountered in true_divide"):
-        with suppress_warnings("invalid value encountered in long_scalars"):
-            optimal_idxs = optimal_idxs.where(
-                optimal_idxs, drop=True
-            ).probability_bin.values
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        optimal_idxs = optimal_idxs.where(
+            optimal_idxs, drop=True
+        ).probability_bin.values
     tpr = tpr.isel(probability_bin=optimal_idxs)
     fpr = fpr.isel(probability_bin=optimal_idxs)
     return fpr, tpr
@@ -1191,12 +1191,15 @@ def _drop_intermediate(fpr, tpr):
 def _auc(fpr, tpr, dim="probability_bin"):
     """Get area under the curve with trapez method."""
     # reverse tpr, fpr to fpr, tpr, see numpy.trapz(y, x=None)
-    with suppress_warnings("The `numpy.trapz` function is not implemented"):
-        with suppress_warnings("invalid value encountered in long_scalars"):
-            with suppress_warnings("invalid value encountered in true_divide"):
-                area = xr.apply_ufunc(
-                    np.trapezoid, tpr, fpr, input_core_dims=[[dim], [dim]], dask="allowed"
-                )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        area = xr.apply_ufunc(
+            np.trapezoid,
+            tpr,
+            fpr,
+            input_core_dims=[[dim], [dim]],
+            dask="allowed",
+        )
     area = abs(area)
     if (area > 1).any():
         area = area.clip(0, 1)  # allow only values between 0 and 1
@@ -1274,7 +1277,7 @@ def roc(
 
     References
     ----------
-    http://www.cawcr.gov.au/projects/verification/
+    https://www.cawcr.gov.au/projects/verification/
     """
 
     if dim is None:

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -46,7 +46,7 @@ FORECAST_PROBABILITY_DIM = "forecast_probability"
 
 def probabilistic_broadcast(
     observations: XArray, forecasts: XArray, member_dim: str = "member"
-) -> XArray:
+) -> Tuple[XArray, ...]:
     """Broadcast dimension except for member_dim in forecasts."""
     observations = observations.broadcast_like(
         forecasts.isel({member_dim: 0}, drop=True)
@@ -113,9 +113,9 @@ def crps_gaussian(
     """
     xmu = xr.DataArray(mu) if isinstance(mu, (int, float)) else mu
     xsig = xr.DataArray(sig) if isinstance(sig, (int, float)) else sig
-    if xmu.dims != observations.dims:
+    if xmu.sizes != observations.sizes:
         observations, xmu = xr.broadcast(observations, xmu)
-    if xsig.dims != observations.dims:
+    if xsig.sizes != observations.sizes:
         observations, xsig = xr.broadcast(observations, xsig)
     res = xr.apply_ufunc(
         properscoring.crps_gaussian,

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -1195,7 +1195,7 @@ def _auc(fpr, tpr, dim="probability_bin"):
         with suppress_warnings("invalid value encountered in long_scalars"):
             with suppress_warnings("invalid value encountered in true_divide"):
                 area = xr.apply_ufunc(
-                    np.trapz, tpr, fpr, input_core_dims=[[dim], [dim]], dask="allowed"
+                    np.trapezoid, tpr, fpr, input_core_dims=[[dim], [dim]], dask="allowed"
                 )
     area = abs(area)
     if (area > 1).any():

--- a/xskillscore/core/utils.py
+++ b/xskillscore/core/utils.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import contextlib
-import warnings
 from typing import List, Tuple
 
 import numpy as np
@@ -11,16 +9,6 @@ from xhistogram.xarray import histogram as xhist
 from .types import Dim, XArray
 
 __all__ = ["histogram"]
-
-
-@contextlib.contextmanager
-def suppress_warnings(msg=None):
-    """Catch warnings with message msg. From
-    https://github.com/TheClimateCorporation/properscoring/blob/master/properscoring/
-    _utils.py#L23."""
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", msg)
-        yield
 
 
 def _preprocess_dims(dim: Dim | None, a: XArray) -> Tuple[List[str], Tuple[int, ...]]:
@@ -142,9 +130,9 @@ def histogram(*args, bins=None, bin_names=None, **kwargs):
         if isinstance(kwargs["dim"], str):
             kwargs["dim"] = [kwargs["dim"]]
     for bin in bins:
-        assert isinstance(
-            bin, np.ndarray
-        ), f"all bins must be numpy arrays, found {type(bin)}"
+        assert isinstance(bin, np.ndarray), (
+            f"all bins must be numpy arrays, found {type(bin)}"
+        )
 
     if isinstance(args[0], xr.Dataset):
         # Get list of variables that are shared across all Datasets

--- a/xskillscore/tests/test_deterministic.py
+++ b/xskillscore/tests/test_deterministic.py
@@ -333,7 +333,7 @@ def test_dim_None(a, b, metrics):
     else:
         metric, _metric = metrics
         res = metric(a, b, dim=None)
-        assert len(res.dims) == 0, print(res.dims)
+        assert len(res.sizes) == 0, print(res.sizes)
 
 
 @pytest.mark.parametrize(
@@ -352,7 +352,7 @@ def test_dim_empty_list(a, b, metrics):
     elif metrics in distance_metrics:
         metric, _metric = metrics
         res = metric(a, b, dim=[])
-        assert len(res.dims) == len(a.dims), print(res.dims)
+        assert len(res.sizes) == len(a.sizes), print(res.sizes)
 
 
 @pytest.mark.parametrize(

--- a/xskillscore/tests/test_metric_results_accurate.py
+++ b/xskillscore/tests/test_metric_results_accurate.py
@@ -62,7 +62,7 @@ def test_xs_same_as_skl(a_1d, b_1d, xs_skl_metrics):
 
 def test_xs_same_as_skl_rmse(a_1d, b_1d):
     actual = rmse(a_1d, b_1d, "time")
-    expected = mean_squared_error(a_1d, b_1d, squared=False)
+    expected = np.sqrt(mean_squared_error(a_1d, b_1d))
     assert np.allclose(actual, expected)
 
 

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -680,7 +680,7 @@ def test_2_category_rps_equals_brier_score(o, f_prob, fair_bool):
             category_edges=category_edges,
             dim=None,
             fair=fair_bool,
-        ).drop(["forecasts_category_edge", "observations_category_edge"]),
+        ).drop_vars(["forecasts_category_edge", "observations_category_edge"]),
         brier_score(o > 0.5, (f_prob > 0.5), dim=None, fair=fair_bool),
     )
 
@@ -855,7 +855,7 @@ def test_rps_new_identical_old_xhistogram(o, f_prob, fair_bool):
     expected = rps_xhist(o, f_prob, dim=dim, category_edges=category_edges_np)
     drop = ["observations_category_edge", "forecasts_category_edge"]
     assert_allclose(
-        actual.rename("histogram_category_edge").drop(drop), expected.drop(drop)
+        actual.rename("histogram_category_edge").drop_vars(drop), expected.drop_vars(drop)
     )
 
 
@@ -906,7 +906,7 @@ def test_roc_returns(
             np.random.normal(size=(100)), coords=[("time", np.arange(100))]
         )
     else:
-        times = xr.cftime_range(start="2000", freq="D", periods=10)
+        times = xr.date_range(start="2000", freq="D", periods=10, use_cftime=True)
         lats = np.arange(4)
         lons = np.arange(5)
         data_obs = np.random.randint(0, 10, size=(len(times), len(lats), len(lons)))

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -243,7 +243,7 @@ def test_threshold_brier_score_api_and_inputs(
         # test for numerical identity of xs threshold and properscoring threshold
         if keep_attrs:
             expected = expected.assign_attrs(**actual.attrs)
-        assert_identical(actual, expected)
+        npt.assert_allclose(actual, expected, rtol=1e7)
     # test that returns chunks
     assert_chunk(actual, chunk_bool)
     # test that attributes are kept

--- a/xskillscore/tests/test_weighted_metric_results_accurate.py
+++ b/xskillscore/tests/test_weighted_metric_results_accurate.py
@@ -70,9 +70,9 @@ def test_xs_same_as_skl_weighted(a_1d, b_1d, weights_linear_time_1d, xs_skl_metr
 
 def test_xs_same_as_skl_rmse_weighted(a_1d, b_1d, weights_linear_time_1d):
     actual = rmse(a_1d, b_1d, "time", weights_linear_time_1d)
-    expected = mean_squared_error(
-        a_1d, b_1d, squared=False, sample_weight=weights_linear_time_1d
-    )
+    expected = np.sqrt(mean_squared_error(
+        a_1d.values, b_1d.values, sample_weight=weights_linear_time_1d
+    ))
     assert np.allclose(actual, expected)
 
 

--- a/xskillscore/tests/test_weighted_metric_results_accurate.py
+++ b/xskillscore/tests/test_weighted_metric_results_accurate.py
@@ -70,9 +70,11 @@ def test_xs_same_as_skl_weighted(a_1d, b_1d, weights_linear_time_1d, xs_skl_metr
 
 def test_xs_same_as_skl_rmse_weighted(a_1d, b_1d, weights_linear_time_1d):
     actual = rmse(a_1d, b_1d, "time", weights_linear_time_1d)
-    expected = np.sqrt(mean_squared_error(
-        a_1d.values, b_1d.values, sample_weight=weights_linear_time_1d
-    ))
+    expected = np.sqrt(
+        mean_squared_error(
+            a_1d.values, b_1d.values, sample_weight=weights_linear_time_1d
+        )
+    )
     assert np.allclose(actual, expected)
 
 

--- a/xskillscore/versioning/print_versions.py
+++ b/xskillscore/versioning/print_versions.py
@@ -130,7 +130,7 @@ def main():
         "--json",
         metavar="FILE",
         nargs=1,
-        help="Save output as JSON into file, pass in " "'-' to output to stdout",
+        help="Save output as JSON into file, pass in '-' to output to stdout",
     )
 
     (options, args) = parser.parse_args()


### PR DESCRIPTION
# Description

This Pull Request addresses several previous `DeprecationWarnings` that are fully deprecated in more modern version of `numpy` and `scikit-learn`. It also suppresses several warnings raised by `numpy` during the testing suite. This adds a pin on `numpy` (v1.25+) and `numba` (v0.57+).

I've also removed the `suppress_warnings()` function, as the number of possible `RuntimeWarnings` was beyond reasonable, especially when comparing older and newer scientific Python libraries (different categorizations were possible). The `warnings.filter(RuntimeWarning)` approach is more powerful.

It also simplifies the `complete` installation recipe by reusing the `xskillscore[test]` recipe.

Addresses problems identified in https://github.com/pangeo-data/climpred/pull/870

Changes here supersede existing Pull Requests:
 - closes #420 
 - closes #424 

## Type of change

Please delete options that are not relevant.

-   [x]  Bug fix (non-breaking change which fixes an issue)
-   [x]  Refactoring
-   [x]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
    - Dependencies have been updated.
    - `suppress_warnings()` was removed (not part of the User API).

# How Has This Been Tested?

This has been tested locally using `pytest` and Python 3.11. GitHub Workflows have been slightly modified (and will continue to be modified in subsequent commits).

## Checklist (while developing)

- N/A

## Pre-Merge Checklist (final steps)

-   [x]  I have rebased onto main or develop (wherever I am merging) and dealt with any conflicts.
-   [ ]  I have squashed commits to a reasonable amount, and force-pushed the squashed commits.
  -  Will squash commits on merge 

## Discussion

This Pull Request is required in order to support downstream libraries that rely on newer Python versions (Python 3.12/3.13) and modern scientific Python libraries (`numpy`, `scipy`, `scikit-learn`, `xarray`, etc.).