### PR TITLE
Use setuptools-scm for packge version handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ build
 
 # Documentation
 docs/build/
+
+# setuptools-scm
+xskillscore/_version.py

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Internal Changes
   :py:func:`warnings.filterwarnings`. (:pr:`426`) `Trevor James Smith`_
 - The minimum supported versions for several dependencies have been
   updated. (:pr:`426`) `Trevor James Smith`_
+- `xskillscore` now uses `setuptools-scm` to automatically determine the
+  version number. (:pr:`427`) `Trevor James Smith`_
 
 
 xskillscore v0.0.26 (2024-03-10)

--- a/docs/source/contributors.rst
+++ b/docs/source/contributors.rst
@@ -8,6 +8,7 @@ Contributors
 * mcsitter (`github <https://github.com/mcsitter/>`__)
 * Ray Bell (`github <https://github.com/raybellwaves/>`__
 * Riley X. Brady (`github <https://github.com/bradyrx/>`__)
+* Trevor James Smith (`github <https://github.com/Zeitsperre/>`__)
 * Zachary Blackwood (`github <https://github.com/blackary/>`__)
 
 For a list of all the contributions, see the github

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,9 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools>=64", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "xskillscore"
-version = "0.0.26"
 dependencies = [
   "dask[array] >=2023.4.0",
   "numpy >=1.24",
@@ -33,7 +32,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 license = {file = "LICENSE.txt"}
-dynamic = ["readme"]
+dynamic = ["readme", "version"]
 
 [project.optional-dependencies]
 accel = ["bottleneck", "numba>=0.52"]
@@ -73,6 +72,7 @@ packages = ["xskillscore"]
 
 [tool.setuptools_scm]
 fallback_version = "9999"
+version_file = "xskillscore/_version.py"
 
 [tool.setuptools.dynamic]
 readme = {file = ["README.rst"], content-type = "text/markdown"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,12 +35,11 @@ license = {file = "LICENSE.txt"}
 dynamic = ["readme", "version"]
 
 [project.optional-dependencies]
-accel = ["bottleneck", "numba>=0.52"]
+accel = ["bottleneck", "numba >=0.57"]
 test = [
-    "bottleneck",
+    "xskillscore[accel]",
     "cftime",
     "matplotlib",
-    "numba >=0.57",
     "pre-commit",
     "pytest",
     "pytest-cov",

--- a/xskillscore/__init__.py
+++ b/xskillscore/__init__.py
@@ -1,3 +1,5 @@
+from importlib.metadata import version, PackageNotFoundError
+
 # ruff: noqa
 from xskillscore.core import resampling
 from xskillscore.core.accessor import XSkillScoreAccessor
@@ -37,4 +39,8 @@ from xskillscore.core.resampling import resample_iterations, resample_iterations
 from xskillscore.core.stattests import multipletests
 from xskillscore.versioning.print_versions import show_versions
 
-__version__ = "0.0.26"
+try:
+    __version__ = version("xskillscore")
+except PackageNotFoundError:
+    # package is not installed
+    pass


### PR DESCRIPTION
# Description

This change makes two very small changes:

1. The package now implements `setuptools-scm`. What this now means is that versioning is entirely dependent on git tags and commits, i.e. commits that are tagged will show their version according to the tag (e.g. `0.0.27`), while commits after this tag will have subsequent build history information (e.g. `0.0.27.dev66+g4e99390.d20250513`). All of this is automated thanks to a new `_version.py` file which is ignored by `git` and generated on-the-fly when building or installing the package. In other words, no more need to manage versioning within the codebase. `xskillscore.__version__` works almost exactly as before.
2. In my last PR, I forgot to modify the `accel` recipe. This now installs the relevant `numba` version and is used to compose the `test` recipe to reduce redundant configurations.

This PR also adds my contributor information.

If the maintainers wish it, I (or you) can update the release date.

## Type of change

Please delete options that are not relevant.

-   [x]  New feature (non-breaking change which adds functionality)
-   [x]  Refactoring

# How Has This Been Tested?

Locally tested using:
```
$ python -m build
$ python -m pip install -e .
```

## Checklist (while developing)

N/A

## Pre-Merge Checklist (final steps)

-   [x]  I have rebased onto main or develop (wherever I am merging) and dealt with any conflicts.
-   [ ]  I have squashed commits to a reasonable amount, and force-pushed the squashed commits.

## References

https://setuptools-scm.readthedocs.io/en/stable/usage/