### PR TITLE
Fix support for numpy<2.0 and pearson_r with numpy>2.0

### DIFF
--- a/.github/workflows/xskillscore_testing.yml
+++ b/.github/workflows/xskillscore_testing.yml
@@ -51,6 +51,10 @@ jobs:
           environment-file: ci/minimum-tests.yml
           create-args: >
             python=${{ matrix.python-version }}
+      - name: Install minimal numpy
+        if: matrix.python-version == '3.9'
+        run: |
+          micromamba install numpy==1.24
       - name: Run tests
         run: |
           pytest -n 4 --cov=xskillscore --cov-report=xml --verbose

--- a/xskillscore/core/np_deterministic.py
+++ b/xskillscore/core/np_deterministic.py
@@ -417,7 +417,7 @@ def _pearson_r_eff_p_value(a, b, axis, skipna):
         _b = 0.5
         res = special.betainc(_a, _b, _x)
         # reset masked values to nan
-        nan_locs = np.where(np.isnan(r))
+        nan_locs = np.where(np.isnan(np.atleast_1d(r)))
         if len(nan_locs[0]) > 0:
             res[nan_locs] = np.nan
         return res

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -31,7 +31,7 @@ except ImportError:
 try:
     from numpy import trapezoid
 except ImportError:
-    from numpy import trapz as trapezoid
+    from numpy import trapz as trapezoid  # type: ignore[no-redef]
 
 __all__ = [
     "brier_score",

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -28,6 +28,11 @@ try:
 except ImportError:
     from scipy.stats import rankdata
 
+try:
+    from numpy import trapezoid
+except ImportError:
+    from numpy import trapz as trapezoid
+
 __all__ = [
     "brier_score",
     "crps_ensemble",
@@ -1158,7 +1163,7 @@ def _auc(fpr, tpr, dim="probability_bin"):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", RuntimeWarning)
         area = xr.apply_ufunc(
-            np.trapezoid,
+            trapezoid,
             tpr,
             fpr,
             input_core_dims=[[dim], [dim]],


### PR DESCRIPTION
# Description

This fix deals with an oversight in the last release that accidentally dropped support for numpy v1. It also fixes a very small bug that can occur in numpy v2.0+, where a single value Pearson R (non-`np.ndarray`) can cause a `ValueError`.

Closes #430 

## Type of change

Please delete options that are not relevant.

-   [x]  Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally with numpy v1.26 (should work fine with numpy v1.24) and numpy v2.0.

## Pre-Merge Checklist (final steps)

-   [x]  I have rebased onto main or develop (wherever I am merging) and dealt with any conflicts.
-   [ ]  I have squashed commits to a reasonable amount, and force-pushed the squashed commits.

## References
