### PR TITLE
Prepare release v0.0.28, pin numpy below v2.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
     rev: v0.4.3
     hooks:
       - id: blackdoc
-        additional_dependencies: ["black==25.1.0"]
+        additional_dependencies: ["black==25.9.0"]
 
   - repo: https://github.com/PyCQA/doc8
     rev: v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ ci:
   autofix_prs: true
   autoupdate_branch: ""
   autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
-  autoupdate_schedule: quarterly
+  autoupdate_schedule: 'quarterly'
   skip: []
   submodules: false
 
@@ -24,17 +24,17 @@ repos:
       - id: check-merge-conflict
       - id: check-toml
       - id: check-yaml
-        args: ["--allow-multiple-documents"]
+        args: [ "--allow-multiple-documents" ]
       - id: debug-statements
       - id: end-of-file-fixer
       - id: no-commit-to-branch
       - id: pretty-format-json
-        args: ["--autofix", "--no-ensure-ascii", "--no-sort-keys"]
+        args: [ "--autofix", "--no-ensure-ascii", "--no-sort-keys" ]
         exclude: ".ipynb|asv.conf.json"
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.13.3"
+    rev: "v0.14.13"
     hooks:
       - id: ruff-check
         args: [ "--fix" ]
@@ -43,10 +43,10 @@ repos:
         types_or: [python, pyi, jupyter]
 
   - repo: https://github.com/keewis/blackdoc
-    rev: v0.4.3
+    rev: v0.4.6
     hooks:
       - id: blackdoc
-        additional_dependencies: ["black==25.9.0"]
+        additional_dependencies: [ 'black==25.9.0' ]
 
   - repo: https://github.com/PyCQA/doc8
     rev: v2.0.0
@@ -62,23 +62,23 @@ repos:
           ]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.18.2"
+    rev: "v1.19.1"
     hooks:
       - id: mypy
         exclude: "asv_bench"
         additional_dependencies: [
             # Type stubs
-            types-python-dateutil,
-            types-setuptools,
-            types-PyYAML,
-            types-pytz,
-            typing-extensions,
+            'types-python-dateutil',
+            'types-setuptools',
+            'types-PyYAML',
+            'types-pytz',
+            'typing-extensions',
             # Dependencies that are typed
-            numpy,
+            'numpy',
           ]
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.34.0
+    rev: 0.36.0
     hooks:
       - id: check-github-workflows
       - id: check-readthedocs

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,18 @@ Changelog History
 =================
 
 
+xskillscore v0.0.28 (2025-10-15)
+--------------------------------
+
+Bug Fixes
+~~~~~~~~~
+- Fixed a bug introduced in v0.0.27 where `numpy` v1.x support was broken for some
+  algorithms. (:pr:`431`) `Trevor James Smith`_.
+- Removed all `numpy.atleast_1d()` calls that were causing numerical differences in
+  p-value calculations with `numpy` v2.x and fixed several doctest expected outputs.
+  (:pr:`440`) `Aaron Spring`_.
+
+
 xskillscore v0.0.27 (2025-07-14)
 --------------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,8 @@ Bug Fixes
 Internal Changes
 ~~~~~~~~~~~~~~~~
 - Pinned `numpy` below v2.4 due to breaking API changes. (:pr:`441`) `Trevor James Smith`_
-- Adjusted tests to adapt to new `xarray` attributes preservation behaviour. (:pr:`441`) `Trevor James Smith`_
+- Adjusted tests to adapt to new `xarray` attributes preservation
+  behaviour. (:pr:`441`) `Trevor James Smith`_
 
 xskillscore v0.0.27 (2025-07-14)
 --------------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog History
 =================
 
 
-xskillscore v0.0.28 (2025-10-15)
+xskillscore v0.0.28 (2025-01-19)
 --------------------------------
 
 Bug Fixes
@@ -14,6 +14,10 @@ Bug Fixes
   p-value calculations with `numpy` v2.x and fixed several doctest expected outputs.
   (:pr:`440`) `Aaron Spring`_.
 
+Internal Changes
+~~~~~~~~~~~~~~~~
+- Pinned `numpy` below v2.4 due to breaking API changes. (:pr:`441`) `Trevor James Smith`_
+- Adjusted tests to adapt to new `xarray` attributes preservation behaviour. (:pr:`441`) `Trevor James Smith`_
 
 xskillscore v0.0.27 (2025-07-14)
 --------------------------------

--- a/ci/dev.yml
+++ b/ci/dev.yml
@@ -18,7 +18,7 @@ dependencies:
   - cftime
   - dask-core >=2023.4.0
   - numba >=0.57
-  - numpy >=1.24
+  - numpy >=1.24,<2.4
   - properscoring
   - scikit-learn
   - scipy >=1.10.0

--- a/ci/doc.yml
+++ b/ci/doc.yml
@@ -12,7 +12,8 @@ dependencies:
   - ipython
   - matplotlib-base
   - nbsphinx
-  - numpy >=1.24
+  - numba >=0.57
+  - numpy >=1.24,<2.4
   - properscoring
   - scikit-learn
   - scipy >=1.10

--- a/ci/docs_notebooks.yml
+++ b/ci/docs_notebooks.yml
@@ -10,7 +10,7 @@ dependencies:
   - dask-core >=2023.4.0
   - doc8
   - numba >=0.57
-  - numpy >=1.24
+  - numpy >=1.24,<2.4
   - properscoring
   - ipykernel
   - jupyterlab

--- a/ci/minimum-tests.yml
+++ b/ci/minimum-tests.yml
@@ -9,7 +9,8 @@ dependencies:
   - coveralls
   - dask-core >=2023.4.0
   - matplotlib-base
-  - numpy >=1.24
+  - numba >=0.57
+  - numpy >=1.24,<2.4
   - properscoring
   - pytest
   - pytest-cov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "xskillscore"
 dependencies = [
   "dask[array] >=2023.4.0",
-  "numpy >=1.24",
+  "numpy >=1.24,<2.4",
   "properscoring",
   "scipy >=1.10",
   "statsmodels",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ test = [
     "xskillscore[accel]",
     "cftime",
     "matplotlib",
+    "packaging",
     "pre-commit",
     "pytest",
     "pytest-cov",

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -28,10 +28,11 @@ try:
 except ImportError:
     from scipy.stats import rankdata
 
+# Remove when `numpy` v1.x support is dropped
 try:
     from numpy import trapezoid
 except ImportError:
-    from numpy import trapz as trapezoid  # type: ignore[no-redef]
+    from numpy import trapz as trapezoid  # type: ignore[attr-defined,no-redef]
 
 __all__ = [
     "brier_score",

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -2,6 +2,7 @@ import warnings
 
 import numpy as np
 import numpy.testing as npt
+from packaging.version import Version
 import properscoring
 import pytest
 import xarray as xr
@@ -64,12 +65,18 @@ def assert_chunk(actual, chunk_bool):
 
 
 def assert_keep_attrs(actual, o, keep_attrs):
-    """check that actual kept attributes only if keep_attrs==True."""
+    """
+    check that actual kept attributes only if keep_attrs==True.
+    
+    For newer xarray versions, attributes are preserved by default.
+    """
     if keep_attrs:
         assert actual.attrs == o.attrs
     else:
+        if Version(xr.__version__) >= Version("2025.11.0"):
+            if "source" in actual.attrs:
+                del actual.attrs["source"]
         assert actual.attrs == {}
-
 
 def assign_type_input_output(actual, o):
     assert isinstance(o, type(actual))

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -2,11 +2,11 @@ import warnings
 
 import numpy as np
 import numpy.testing as npt
-from packaging.version import Version
 import properscoring
 import pytest
 import xarray as xr
 from dask import is_dask_collection
+from packaging.version import Version
 from scipy.stats import norm
 from sklearn.calibration import calibration_curve
 from sklearn.metrics import roc_auc_score, roc_curve
@@ -67,7 +67,7 @@ def assert_chunk(actual, chunk_bool):
 def assert_keep_attrs(actual, o, keep_attrs):
     """
     check that actual kept attributes only if keep_attrs==True.
-    
+
     For newer xarray versions, attributes are preserved by default.
     """
     if keep_attrs:
@@ -77,6 +77,7 @@ def assert_keep_attrs(actual, o, keep_attrs):
             if "source" in actual.attrs:
                 del actual.attrs["source"]
         assert actual.attrs == {}
+
 
 def assign_type_input_output(actual, o):
     assert isinstance(o, type(actual))


### PR DESCRIPTION
# Description

Prepares the next release (v0.0.28) of `xskillscore`.

It's entirely possible that this release closes a few existing issues; Will do a look-over after release.

Closes #443 

## Type of change

- Software release preparation PR.
- `pre-commit` autoupdate.
- `numpy` has been pinned below v2.4 due to breaking changes.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. This could point to a cell in the updated notebooks. Or a snippet of code with accompanying figures here.

## Checklist (while developing)

N/A

## Pre-Merge Checklist (final steps)

-   [x]  I have rebased onto main or develop (wherever I am merging) and dealt with any conflicts.
-   [x]  I have squashed commits to a reasonable amount, and force-pushed the squashed commits.




