### PR TITLE
Release v0.0.29

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ xskillscore v0.0.29 (2026-02-18)
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
-- Lifted `numpy<2` dependency constraint and bumped minimum to `numpy>=1.25`.
+- Lifted `numpy<2.4` dependency constraint and bumped minimum to `numpy>=1.25`.
   (:pr:`444`) `Aaron Spring`_
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,16 @@ Changelog History
 =================
 
 
-xskillscore v0.0.28 (2025-01-19)
+xskillscore v0.0.29 (2026-02-18)
+--------------------------------
+
+Internal Changes
+~~~~~~~~~~~~~~~~
+- Lifted `numpy<2` dependency constraint and bumped minimum to `numpy>=1.25`.
+  (:pr:`444`) `Aaron Spring`_
+
+
+xskillscore v0.0.28 (2026-01-19)
 --------------------------------
 
 Bug Fixes
@@ -16,11 +25,10 @@ Bug Fixes
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
-- Lifted `numpy<2` dependency constraint and bumped minimum to `numpy>=1.25`.
-  (:pr:`444`) `Aaron Spring`_
 - Pinned `numpy` below v2.4 due to breaking API changes. (:pr:`441`) `Trevor James Smith`_
 - Adjusted tests to adapt to new `xarray` attributes preservation
   behaviour. (:pr:`441`) `Trevor James Smith`_
+- Updated pre-commit configuration. (:pr:`434`)
 
 xskillscore v0.0.27 (2025-07-14)
 --------------------------------


### PR DESCRIPTION
## Summary
- Prepare release v0.0.29
- Add CHANGELOG entry for PR #444 (lift `numpy<2.4` constraint, bump minimum to `numpy>=1.25`)
- Fix v0.0.28 release date (was incorrectly 2025-01-19, corrected to 2026-01-19)
- Add PR #434 to v0.0.28 changelog

## Changes since v0.0.28 (2026-01-19)
- PR #444: Lift `numpy<2.4` dependency constraint and bump minimum to `numpy>=1.25`