### PR TITLE
Fix wheel build missing subpackages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,8 +67,8 @@ complete = [
 repository = "https://github.com/xarray-contrib/xskillscore"
 documentation = "https://xskillscore.readthedocs.io/en/stable/"
 
-[tool.setuptools]
-packages = ["xskillscore"]
+[tool.setuptools.packages.find]
+where = ["."]
 
 [tool.setuptools_scm]
 fallback_version = "9999"


### PR DESCRIPTION
## Summary

- Replaces `packages = ["xskillscore"]` with `[tool.setuptools.packages.find]` auto-discovery
- The old config caused `xskillscore.core`, `xskillscore.versioning`, and `xskillscore.tests` to be omitted from built wheels, making installed packages non-functional
- Auto-discovery picks up all subpackages automatically, including any added in future

Closes #423

## Test plan

- [ ] Verify `python -m build --wheel` produces a wheel containing `xskillscore/core/`, `xskillscore/versioning/`
- [ ] Existing test suite passes (`pytest -n auto`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)