### PR TITLE
Add keep_attrs to discrimination and Contingency

### DIFF
--- a/xskillscore/core/contingency.py
+++ b/xskillscore/core/contingency.py
@@ -67,6 +67,8 @@ class Contingency:
         exclude the right edge. The last bin includes both edges.
     dim : str, list
         The dimension(s) over which to compute the contingency table
+    keep_attrs : bool, optional
+        Whether to copy attributes from the observations to the contingency table.
 
     Returns
     -------
@@ -107,6 +109,7 @@ class Contingency:
         observation_category_edges: xr.DataArray | np.ndarray,
         forecast_category_edges: xr.DataArray | np.ndarray,
         dim: Dim,
+        keep_attrs: bool = False,
     ):
         self._observations = observations.copy()
         self._forecasts = forecasts.copy()
@@ -117,7 +120,7 @@ class Contingency:
             if (len(observation_category_edges) - 1 == 2) & (len(forecast_category_edges) - 1 == 2)
             else False
         )
-        self._table = self._get_contingency_table(dim)
+        self._table = self._get_contingency_table(dim, keep_attrs)
 
     @property
     def observations(self):
@@ -143,13 +146,15 @@ class Contingency:
     def table(self):
         return self._table
 
-    def _get_contingency_table(self, dim: Dim) -> XArray:
+    def _get_contingency_table(self, dim: Dim, keep_attrs: bool) -> XArray:
         """Build the contingency table
 
         Parameters
         ----------
         dim : str, list
             The dimension(s) over which to compute the contingency table
+        keep_attrs : bool
+            Whether to copy attributes from the observations to the table.
 
         Returns
         -------
@@ -190,6 +195,17 @@ class Contingency:
                 FORECASTS_NAME + "_category_bounds": FORECASTS_NAME + "_category",
             }
         )
+
+        if keep_attrs:
+            table.attrs.update(self.observations.attrs)
+            if isinstance(table, xr.Dataset):
+                for var in table.data_vars:
+                    table[var].attrs.update(self.observations[var].attrs)
+        else:
+            table.attrs.clear()
+            if isinstance(table, xr.Dataset):
+                for var in table.data_vars:
+                    table[var].attrs.clear()
 
         return table
 

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -958,6 +958,7 @@ def discrimination(
     forecasts: XArray,
     dim: Optional[Dim] = None,
     probability_bin_edges: xr.DataArray | np.ndarray = np.linspace(0, 1, 6),
+    keep_attrs: bool = False,
 ) -> XArray:
     """Returns the data required to construct the discrimination diagram for an event;
        the histogram of forecasts likelihood when observations indicate an event has
@@ -979,6 +980,8 @@ def discrimination(
         all but the last (righthand-most) bin include the left edge and exclude the \
         right edge. The last bin includes both edges. Defaults to 6 equally spaced \
         edges between 0 and 1
+    keep_attrs : bool, optional
+        Whether to copy attributes from the first argument to the output.
 
     Returns
     -------
@@ -1041,17 +1044,24 @@ def discrimination(
 
     # Reconstruct to ensure coordinate order, but preserve Dataset vs DataArray type
     if isinstance(result, xr.DataArray):
-        return xr.DataArray(
+        result = xr.DataArray(
             result.data,  # Use .data instead of .values to preserve dask arrays
             dims=result.dims,
             coords={
                 "event": result.coords["event"],
                 FORECAST_PROBABILITY_DIM: result.coords[FORECAST_PROBABILITY_DIM],
             },
+            attrs=observations.attrs if keep_attrs else None,
         )
+    elif keep_attrs:
+        result.attrs.update(observations.attrs)
+        for var in result.data_vars:
+            result[var].attrs.update(observations[var].attrs)
     else:
-        # For Dataset, reconstruct each data variable
-        return result
+        result.attrs.clear()
+        for var in result.data_vars:
+            result[var].attrs.clear()
+    return result
 
 
 def reliability(

--- a/xskillscore/tests/test_contingency.py
+++ b/xskillscore/tests/test_contingency.py
@@ -15,8 +15,12 @@ CATEGORY_EDGES = [
 @pytest.mark.parametrize("type", ["da", "ds", "chunked_da", "chunked_ds"])
 @pytest.mark.parametrize("dim", DIMS)
 @pytest.mark.parametrize("category_edges", CATEGORY_EDGES)
-def test_Contingency_table(observation_3d_int, forecast_3d_int, category_edges, dim, type):
+@pytest.mark.parametrize("keep_attrs", [True, False])
+def test_Contingency_table(
+    observation_3d_int, forecast_3d_int, category_edges, dim, type, keep_attrs
+):
     """Test that contingency table builds successfully"""
+    observation_3d_int.attrs = {"source": "observations"}
     if "ds" in type:
         name = "var"
         observation_3d_int = observation_3d_int.to_dataset(name=name)
@@ -25,9 +29,20 @@ def test_Contingency_table(observation_3d_int, forecast_3d_int, category_edges, 
         observation_3d_int = observation_3d_int.chunk()
         forecast_3d_int = forecast_3d_int.chunk()
     cont_table = Contingency(
-        observation_3d_int, forecast_3d_int, category_edges, category_edges, dim=dim
+        observation_3d_int,
+        forecast_3d_int,
+        category_edges,
+        category_edges,
+        dim=dim,
+        keep_attrs=keep_attrs,
     )
     assert cont_table
+    actual = cont_table.table["var"] if "ds" in type else cont_table.table
+    expected = observation_3d_int["var"] if "ds" in type else observation_3d_int
+    if keep_attrs:
+        assert actual.attrs == expected.attrs
+    else:
+        assert actual.attrs == {}
 
 
 @pytest.mark.parametrize("category_edges", CATEGORY_EDGES)

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -377,18 +377,25 @@ def test_rank_histogram_values(o, f_prob):
 @pytest.mark.parametrize("dim", DIMS)
 @pytest.mark.parametrize("chunk_bool", [True, False])
 @pytest.mark.parametrize("input_type", ["DataArray", "Dataset", "multidim Dataset"])
-def test_discrimination_sum(o, f_prob, dim, chunk_bool, input_type):
+@pytest.mark.parametrize("keep_attrs", [True, False])
+def test_discrimination_sum(o, f_prob, dim, chunk_bool, input_type, keep_attrs):
     """Test that the probabilities sum to 1"""
     o, f_prob = modify_inputs(o, f_prob, input_type, chunk_bool)
     if dim == []:
         with pytest.raises(ValueError):
             discrimination(o > 0.5, (f_prob > 0.5).mean("member"), dim=dim)
     else:
-        disc = discrimination(o > 0.5, (f_prob > 0.5).mean("member"), dim=dim)
+        disc = discrimination(
+            o > 0.5,
+            (f_prob > 0.5).mean("member"),
+            dim=dim,
+            keep_attrs=keep_attrs,
+        )
         # test that input types equal output types
         assign_type_input_output(disc, o)
         if "Dataset" in input_type:
             disc = disc[list(o.data_vars)[0]]
+            o = o[list(o.data_vars)[0]]
         # don't understand the error message here, but it appeared
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", RuntimeWarning)
@@ -402,8 +409,8 @@ def test_discrimination_sum(o, f_prob, dim, chunk_bool, input_type):
 
         # test that returns chunks
         assert_chunk(disc, chunk_bool)
-        # test that attributes are kept # TODO: add
-        # assert_keep_attrs(disc, o, keep_attrs)
+        # test that attributes are kept
+        assert_keep_attrs(disc, o, keep_attrs)
 
 
 def test_discrimination_perfect_values(o):
@@ -419,20 +426,29 @@ def test_discrimination_perfect_values(o):
 @pytest.mark.parametrize("dim", DIMS)
 @pytest.mark.parametrize("chunk_bool", [True, False])
 @pytest.mark.parametrize("input_type", ["DataArray", "Dataset", "multidim Dataset"])
-def test_reliability_api_and_inputs(o, f_prob, dim, chunk_bool, input_type):
+@pytest.mark.parametrize("keep_attrs", [True, False])
+def test_reliability_api_and_inputs(o, f_prob, dim, chunk_bool, input_type, keep_attrs):
     """Test that reliability keeps chunking and input types."""
     o, f_prob = modify_inputs(o, f_prob, input_type, chunk_bool)
     if isinstance(dim, list) and len(dim) == 0:
         with pytest.raises(ValueError):
             reliability(o > 0.5, (f_prob > 0.5).mean("member"), dim)
     else:
-        actual = reliability(o > 0.5, (f_prob > 0.5).mean("member"), dim=dim)
+        actual = reliability(
+            o > 0.5,
+            (f_prob > 0.5).mean("member"),
+            dim=dim,
+            keep_attrs=keep_attrs,
+        )
         # test that returns chunks
         assert_chunk(actual, chunk_bool)
-        # test that attributes are kept
-        # assert_keep_attrs(actual, o, keep_attrs) # TODO: implement
         # test that input types equal output types
         assign_type_input_output(actual, o)
+        # test that attributes are kept
+        if "Dataset" in input_type:
+            actual = actual[list(o.data_vars)[0]]
+            o = o[list(o.data_vars)[0]]
+        assert_keep_attrs(actual, o, keep_attrs)
 
 
 def test_reliability_values(o, f_prob):


### PR DESCRIPTION
# Description

Completes the remaining keep_attrs support requested in #258.

- adds keep_attrs=False to discrimination
- adds keep_attrs=False to Contingency
- preserves observation attributes for DataArray and Dataset outputs when requested
- explicitly clears output attributes when keep_attrs=False, keeping behavior stable across xarray versions
- activates the existing reliability attribute test and covers eager, Dask, DataArray, Dataset, and multidimensional Dataset inputs

Closes #258

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- uv run --extra test pytest -q (2894 passed, 3 skipped)
- pre-commit on all four changed files (all applicable hooks passed)

## Checklist (while developing)

- [x] I have added documentation for the new parameters.
- [x] Tests added for pytest.

## Pre-Merge Checklist (final steps)

- [x] Based on the current upstream main.
- [x] Contains one focused commit.
