### PR TITLE
Clarify the halfwidth mean-error difference sign

### DIFF
--- a/xskillscore/core/comparative.py
+++ b/xskillscore/core/comparative.py
@@ -228,6 +228,8 @@ def halfwidth_ci_test(
         example, ``me(a, b)`` computes the mean of ``a - b``, so ``metric="me"``
         returns ``me(observations, forecasts2) - me(observations, forecasts1)``.
         This has the opposite sign from a forecast-minus-observation convention.
+        The sign does not affect ``significantly_different``, which compares the
+        absolute difference with the confidence-interval half-width.
 
     Parameters
     ----------

--- a/xskillscore/core/comparative.py
+++ b/xskillscore/core/comparative.py
@@ -222,6 +222,13 @@ def halfwidth_ci_test(
         Source: NIST/SEMATECH e-Handbook of Statistical Methods.
         https://www.itl.nist.gov/div898/handbook/prc/section1/prc14.htm
 
+    .. note::
+        The sign of the returned difference follows the argument convention of the
+        selected metric, which is called as ``metric(observations, forecast)``. For
+        example, ``me(a, b)`` computes the mean of ``a - b``, so ``metric="me"``
+        returns ``me(observations, forecasts2) - me(observations, forecasts1)``.
+        This has the opposite sign from a forecast-minus-observation convention.
+
     Parameters
     ----------
     forecasts1 : xarray.Dataset or xarray.DataArray


### PR DESCRIPTION
# Description

Clarifies the sign convention behind the difference returned by halfwidth_ci_test.

The function consistently returns score(forecasts2) - score(forecasts1), but each score follows the selected metric argument convention. For mean error, xskillscore defines me(a, b) as mean(a - b) and halfwidth_ci_test calls it as me(observations, forecast). The resulting sign is therefore opposite to calculations that define error as forecast - observation. The sign does not change the significance decision because that comparison uses the absolute difference.

This documents the behavior reported in #413 without changing the existing statistical calculation.

Closes #413

## Type of change

- [x] Bug fix (documentation clarification; no runtime behavior changes)

# How Has This Been Tested?

- uv run --extra test pytest --doctest-modules xskillscore/core/comparative.py -q (2 passed)
- pre-commit on xskillscore/core/comparative.py (all applicable hooks passed)

## Checklist (while developing)

- [x] The updated function documentation builds as a valid doctest module.

## Pre-Merge Checklist (final steps)

- [x] Based on the current upstream main.
