### PR TITLE
Add fair (ensemble-size adjusted) option to crps_ensemble (Ferro 2014)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,13 @@ Breaking Changes
 - Dropped support for Python 3.9. The minimum supported version is now Python 3.10.
   `Aaron Spring`_
 
+Features
+~~~~~~~~
+- Added ``fair`` keyword to :py:func:`~xskillscore.crps_ensemble` implementing the
+  ensemble-size adjusted, unbiased CRPS of Ferro (2014), matching the ``fair``
+  keyword of :py:func:`~xskillscore.rps` and :py:func:`~xskillscore.brier_score`.
+  (:issue:`461`) `Aaron Spring`_
+
 Documentation
 ~~~~~~~~~~~~~
 - Made the documentation discoverable and parseable by LLMs and coding agents by

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Features
 - Added ``fair`` keyword to :py:func:`~xskillscore.crps_ensemble` implementing the
   ensemble-size adjusted, unbiased CRPS of Ferro (2014), matching the ``fair``
   keyword of :py:func:`~xskillscore.rps` and :py:func:`~xskillscore.brier_score`.
-  (:issue:`461`) `Aaron Spring`_
+  (:issue:`461`, :pr:`462`) `Aaron Spring`_
 
 Documentation
 ~~~~~~~~~~~~~

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -335,8 +335,10 @@ def crps_ensemble(
             M = M.where(M > 1)  # fair CRPS is undefined for M < 2
             skill = abs(forecasts - observations).mean(member_dim)
             # spread = skill - res = 1 / (2 * M ** 2) * sum_ij |x_i - x_j|
-            # hence: fair = skill - spread * M / (M - 1) without O(M**2) memory
-            res = skill - (skill - res) * M / (M - 1)
+            # hence: fair = skill - spread * M / (M - 1) = res - spread / (M - 1),
+            # which avoids O(M**2) memory. res stays the left operand so that
+            # keep_attrs takes the attributes of observations, as for fair=False.
+            res = res - (skill - res) / (M - 1)
     if weights is not None:
         return res.weighted(weights).mean(dim, keep_attrs=keep_attrs)
     else:

--- a/xskillscore/core/probabilistic.py
+++ b/xskillscore/core/probabilistic.py
@@ -215,11 +215,27 @@ def crps_ensemble(
     member_weights: Optional[XArray] = None,
     issorted: bool = False,
     member_dim: str = "member",
+    fair: bool = False,
     dim: Optional[Dim] = None,
     weights: Optional[XArray] = None,
     keep_attrs: bool = False,
 ) -> XArray:
     """Continuous Ranked Probability Score with the ensemble distribution.
+
+    .. math::
+        CRPS(F, o) = \\frac{1}{M} \\sum_{m=1}^{M} |x_m - o|
+                     - \\frac{1}{2 M^{2}} \\sum_{i=1}^{M} \\sum_{j=1}^{M}
+                       |x_i - x_j|
+
+    The ensemble estimator above is biased for finite ensemble size ``M`` and
+    only converges to the true CRPS as ``M`` goes to infinity. ``fair=True``
+    replaces the denominator of the spread term by :math:`M (M-1)`, which
+    yields the unbiased, ensemble-size independent "fair" CRPS of Ferro (2014):
+
+    .. math::
+        CRPS_{fair}(F, o) = \\frac{1}{M} \\sum_{m=1}^{M} |x_m - o|
+                            - \\frac{1}{2 M (M-1)} \\sum_{i=1}^{M}
+                              \\sum_{j=1}^{M} |x_i - x_j|
 
     Parameters
     ----------
@@ -237,6 +253,10 @@ def crps_ensemble(
         already sorted along `axis`.
     member_dim : str, optional
         Name of ensemble member dimension. By default, 'member'.
+    fair: boolean
+        Apply ensemble member-size adjustment for unbiased, fair metric;
+        see Ferro (2014). Requires at least two members and equally weighted
+        members, i.e. ``member_weights=None``. Defaults to False.
     dim : str or list of str, optional
         Dimension over which to compute mean after computing ``crps_ensemble``.
         Defaults to None implying averaging over all dimensions.
@@ -269,13 +289,35 @@ def crps_ensemble(
     Coordinates:
       * y        (y) int64 24B 0 1 2
 
+    >>> xs.crps_ensemble(observations, forecasts, dim="x", fair=True)
+    <xarray.DataArray (y: 3)> Size: 24B
+    array([0.86487601, 0.26399584, 0.3083712 ])
+    Coordinates:
+      * y        (y) int64 24B 0 1 2
+
     See Also
     --------
     properscoring.crps_ensemble
+
+    References
+    ----------
+    * Ferro, C. A. T. (2014). Fair scores for ensemble forecasts. Quarterly
+      Journal of the Royal Meteorological Society, 140(683), 1917–1923.
+      doi: 10.1002/qj.2270.
     """
     observations, forecasts = probabilistic_broadcast(
         observations, forecasts, member_dim=member_dim
     )
+    if fair:
+        if member_weights is not None:
+            raise ValueError(
+                "fair=True is only defined for equally weighted members, "
+                "found member_weights not None."
+            )
+        if forecasts.sizes[member_dim] < 2:
+            raise ValueError(
+                f"fair=True requires at least 2 members, found {forecasts.sizes[member_dim]}."
+            )
     res = xr.apply_ufunc(
         properscoring.crps_ensemble,
         observations,
@@ -286,6 +328,15 @@ def crps_ensemble(
         output_dtypes=[float],
         keep_attrs=keep_attrs,
     )
+    if fair:  # for ensemble member adjustment, see Ferro 2014
+        with xr.set_options(keep_attrs=keep_attrs):
+            # M counts only non-NaN members, matching properscoring's nan handling
+            M = forecasts.notnull().sum(member_dim)
+            M = M.where(M > 1)  # fair CRPS is undefined for M < 2
+            skill = abs(forecasts - observations).mean(member_dim)
+            # spread = skill - res = 1 / (2 * M ** 2) * sum_ij |x_i - x_j|
+            # hence: fair = skill - spread * M / (M - 1) without O(M**2) memory
+            res = skill - (skill - res) * M / (M - 1)
     if weights is not None:
         return res.weighted(weights).mean(dim, keep_attrs=keep_attrs)
     else:

--- a/xskillscore/tests/test_accessor_probabilistic.py
+++ b/xskillscore/tests/test_accessor_probabilistic.py
@@ -54,6 +54,15 @@ def test_crps_ensemble_accessor(o, f_prob, outer_bool):
     assert_allclose(actual, expected)
 
 
+def test_crps_ensemble_fair_accessor(o, f_prob):
+    actual = crps_ensemble(o, f_prob, fair=True)
+    ds = xr.Dataset()
+    ds["o"] = o
+    ds["f_prob"] = f_prob
+    expected = ds.xs.crps_ensemble("o", "f_prob", fair=True)
+    assert_allclose(actual, expected)
+
+
 @pytest.mark.slow
 def test_crps_quadrature_accessor(o):
     # to speed things up

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -119,6 +119,103 @@ def test_crps_ensemble_weighted(o, f_prob, weights_cos_lat):
     assert not (actual_no_weights == actual).all()
 
 
+def crps_ensemble_double_sum(observations, forecasts, fair, member_dim="member"):
+    """Direct O(M**2) double-sum implementation of the (fair) ensemble CRPS."""
+    x_i = forecasts.rename({member_dim: "_i"})
+    x_j = forecasts.rename({member_dim: "_j"})
+    M = forecasts.notnull().sum(member_dim)
+    denominator = 2 * M * (M - 1) if fair else 2 * M**2
+    skill = abs(forecasts - observations).mean(member_dim)
+    spread = abs(x_i - x_j).sum(["_i", "_j"]) / denominator
+    return skill - spread
+
+
+def test_crps_ensemble_fair_hand_computed():
+    """Test fair crps_ensemble against a hand-computed reference."""
+    observations = xr.DataArray(2.0)
+    forecasts = xr.DataArray([1.0, 3.0, 4.0], coords=[("member", [0, 1, 2])])
+    # skill = (1 + 1 + 2) / 3 = 4 / 3
+    # sum_ij |x_i - x_j| = 2 * (2 + 3 + 1) = 12
+    # fair = 4 / 3 - 12 / (2 * 3 * 2) = 1 / 3
+    npt.assert_allclose(
+        crps_ensemble(forecasts=forecasts, observations=observations, fair=True), 1 / 3
+    )
+    # standard = 4 / 3 - 12 / (2 * 3 ** 2) = 2 / 3
+    npt.assert_allclose(crps_ensemble(observations, forecasts, fair=False), 2 / 3)
+
+
+@pytest.mark.parametrize("fair_bool", [True, False])
+def test_crps_ensemble_fair_equals_double_sum(o, f_prob, fair_bool):
+    """Test that the efficient reconstruction equals the direct double-sum."""
+    actual = crps_ensemble(o, f_prob, dim=[], fair=fair_bool)
+    expected = crps_ensemble_double_sum(o, f_prob, fair=fair_bool)
+    assert_allclose(actual, expected)
+
+
+def test_crps_ensemble_fair_default_False(o, f_prob):
+    """Test that fair=False is identical to not specifying fair."""
+    assert_identical(crps_ensemble(o, f_prob), crps_ensemble(o, f_prob, fair=False))
+
+
+def test_crps_ensemble_fair_smaller_than_unfair(o, f_prob):
+    """Test that fair crps_ensemble is smaller than the biased crps_ensemble."""
+    fair = crps_ensemble(o, f_prob, dim=[], fair=True)
+    unfair = crps_ensemble(o, f_prob, dim=[], fair=False)
+    assert (fair <= unfair).all()
+
+
+def test_crps_ensemble_fair_less_biased_than_unfair(o, f_prob):
+    """Test that fair crps_ensemble depends less on ensemble size than unfair."""
+    large = f_prob
+    small = f_prob.isel(member=slice(None, 2))
+    fair_bias = abs(crps_ensemble(o, small, fair=True) - crps_ensemble(o, large, fair=True))
+    unfair_bias = abs(crps_ensemble(o, small, fair=False) - crps_ensemble(o, large, fair=False))
+    assert fair_bias < unfair_bias
+
+
+def test_crps_ensemble_fair_nan_members(o, f_prob):
+    """Test that fair crps_ensemble counts only non-NaN members as M."""
+    f_prob_nan = f_prob.copy()
+    f_prob_nan[-1] = np.nan
+    actual = crps_ensemble(o, f_prob_nan, dim=[], fair=True)
+    # equals dropping the all-NaN member, i.e. M = number of non-NaN members
+    expected = crps_ensemble(o, f_prob.isel(member=slice(None, -1)), dim=[], fair=True)
+    assert_allclose(actual, expected)
+    assert actual.notnull().all()
+
+
+def test_crps_ensemble_fair_member_weights_raises(o, f_prob):
+    """Test that fair crps_ensemble raises for weighted members."""
+    member_weights = xr.ones_like(f_prob)
+    with pytest.raises(ValueError, match="equally weighted members"):
+        crps_ensemble(o, f_prob, member_weights=member_weights, fair=True)
+
+
+def test_crps_ensemble_fair_one_member_raises(o, f_prob):
+    """Test that fair crps_ensemble raises for a single member."""
+    with pytest.raises(ValueError, match="at least 2 members"):
+        crps_ensemble(o, f_prob.isel(member=[0]), fair=True)
+
+
+@pytest.mark.parametrize("chunk_bool", [True, False])
+@pytest.mark.parametrize("input_type", ["Dataset", "multidim Dataset", "DataArray"])
+@pytest.mark.parametrize("keep_attrs", [True, False])
+def test_crps_ensemble_fair_api_and_inputs(o, f_prob, keep_attrs, input_type, chunk_bool):
+    """Test that fair crps_ensemble keeps attributes, chunking and input types."""
+    o, f_prob = modify_inputs(o, f_prob, input_type, chunk_bool)
+    actual = crps_ensemble(o, f_prob, fair=True, keep_attrs=keep_attrs)
+    assert_chunk(actual, chunk_bool)
+    assert_keep_attrs(actual, o, keep_attrs)
+    assign_type_input_output(actual, o)
+
+
+@pytest.mark.parametrize("dim", DIMS)
+def test_crps_ensemble_fair_dim(o, f_prob, dim):
+    """Check that fair crps_ensemble reduces only dim."""
+    actual = crps_ensemble(o, f_prob, dim=dim, fair=True)
+    assert_only_dim_reduced(dim, actual, o)
+
+
 @pytest.mark.parametrize("chunk_bool", [True, False])
 @pytest.mark.parametrize("input_type", ["Dataset", "multidim Dataset", "DataArray"])
 @pytest.mark.parametrize("keep_attrs", [True, False])

--- a/xskillscore/tests/test_probabilistic.py
+++ b/xskillscore/tests/test_probabilistic.py
@@ -184,6 +184,15 @@ def test_crps_ensemble_fair_nan_members(o, f_prob):
     assert actual.notnull().all()
 
 
+@pytest.mark.parametrize("fair_bool", [True, False])
+def test_crps_ensemble_keep_attrs_from_observations(o, f_prob, fair_bool):
+    """Test that crps_ensemble keeps the attributes of observations, not forecasts."""
+    o.attrs = {"source": "observations"}
+    f_prob.attrs = {"source": "forecasts"}
+    actual = crps_ensemble(o, f_prob, fair=fair_bool, keep_attrs=True)
+    assert actual.attrs == o.attrs
+
+
 def test_crps_ensemble_fair_member_weights_raises(o, f_prob):
     """Test that fair crps_ensemble raises for weighted members."""
     member_weights = xr.ones_like(f_prob)


### PR DESCRIPTION
Closes #461. Closes #260.

## Motivation

`xskillscore.crps_ensemble` wraps `properscoring.crps_ensemble`, whose finite-ensemble estimator is **biased** for ensemble size `M` and only converges to the true CRPS as `M → ∞`. A mean CRPS from a 10-member ensemble is therefore not comparable to one from a 50-member ensemble.

`rps` and `brier_score` already expose a `fair` bool for exactly this reason; `crps_ensemble` was the one probabilistic scorer missing it.

## Formula

Standard (biased), denominator `M²`:

```
CRPS_std  = (1/M) Σ_m |x_m − o| − 1/(2 M²)     Σ_i Σ_j |x_i − x_j|
```

Fair (unbiased, Ferro 2014), denominator `M(M−1)`:

```
CRPS_fair = (1/M) Σ_m |x_m − o| − 1/(2 M(M−1)) Σ_i Σ_j |x_i − x_j|
```

Only the spread-term denominator changes.

## Implementation

`fair: bool = False` sits after `member_dim`, matching `brier_score`. The accessor already forwards `**kwargs`, so `ds.xs.crps_ensemble(..., fair=True)` works unchanged.

Rather than materializing the `M × M` pairwise difference array, the fair score is reconstructed from the existing properscoring result:

```python
skill  = mean_m |x_m − o|
spread = skill − CRPS_std            # = 1/(2 M²) ΣΣ|x_i−x_j|
CRPS_fair = skill − spread·M/(M−1)   # == CRPS_std − spread/(M−1)
```

The code uses the right-hand form, `res - (skill - res) / (M - 1)`, which is algebraically identical, one multiplication cheaper, and keeps `res` as the left operand so `keep_attrs=True` takes the attributes of `observations`, exactly as the `fair=False` path does.

`M = forecasts.notnull().sum(member_dim)` counts only non-NaN members per forecast, matching `properscoring`'s own NaN handling (it normalizes by the non-NaN member count), so ragged ensembles come out right. `M` is masked where `M < 2` so the result is NaN instead of a divide-by-zero.

Guards:
- `member_weights is not None` together with `fair=True` raises `ValueError` — the fair adjustment is only defined for equally weighted members.
- fewer than 2 members raises `ValueError`.

## Cross-check against `scores`

Honorable mention: [`scores.probability.crps_for_ensemble`](https://scores.readthedocs.io/en/stable/api.html#scores.probability.crps_for_ensemble) already offers this estimator, via `method="ecdf"` (biased, `M²`) vs `method="fair"` (`M(M−1)`), citing the same Ferro (2014) reference. It computes the spread term differently — sorting along the member dimension and using the closed form `S = 2 Σ_i (2i − M + 1)·x_(i)`, O(M log M) — so it is a genuinely independent implementation. This branch agrees with it to machine precision, including for ragged ensembles with NaN members:

```
properscoring     [3.6376462  0.39310486 0.25281722 0.58443615]
scores ecdf       [3.6376462  0.39310486 0.25281722 0.58443615]
scores fair       [3.54624036 0.3047711  0.1871734  0.47973251]
xskillscore fair  [3.54624036 0.3047711  0.1871734  0.47973251]
```

Two API differences worth noting: `scores` exposes a `method` string rather than a `fair` bool (xskillscore keeps the bool for parity with its own `rps`/`brier_score`), and `scores` has no per-member weighting at all, so the `fair` + `member_weights` conflict guarded against here cannot arise there.

## Downstream climpred

No accompanying climpred PR is needed. [`climpred`'s `_crps`](https://github.com/pangeo-data/climpred/blob/main/src/climpred/metrics.py) already forwards `**metric_kwargs` straight into `xskillscore.crps_ensemble`, and `comparison` is only injected for metrics with `normalize` or `allows_logical` (crps is neither), so the kwarg arrives untouched. Verified end-to-end against this branch:

```python
he.verify(metric="crps", comparison="m2o", dim="member", alignment="same_inits")            # 0.98872613 ...
he.verify(metric="crps", comparison="m2o", dim="member", alignment="same_inits", fair=True) # 0.94633721 ...
```

climpred will only want to raise its `xskillscore>=0.0.29` pin once this is released.

## Tests

Added to `test_probabilistic.py` (and one accessor test):

- hand-computed reference: members `[1, 3, 4]`, obs `2.0` → fair CRPS `1/3`, standard CRPS `2/3`
- efficient reconstruction equals a direct `O(M²)` double-sum implementation, for `fair=True` and `fair=False`
- `fair=False` is `assert_identical` to omitting the kwarg (regression guard)
- fair ≤ unfair everywhere
- fair score depends less on ensemble size than the unfair score (2 vs. all members)
- NaN members: `M` counts only non-NaN members (equals the result of dropping the NaN member)
- `member_weights` + `fair=True` raises; single member + `fair=True` raises
- `keep_attrs=True` returns the attributes of `observations` for both `fair` values, using *distinct* attrs on observations and forecasts (the shared `conftest.py` fixtures cannot catch a swap)
- api/inputs matrix (Dataset / multidim Dataset / DataArray × chunked × `keep_attrs`) and `dim` reduction, mirroring the existing `crps_ensemble` tests
- accessor `ds.xs.crps_ensemble("o", "f_prob", fair=True)`

Full suite: 2823 passed, 3 skipped. Doctests: 32 passed. `pre-commit run --all-files`: clean.

## Docs

- `crps_ensemble` docstring gains the `fair` parameter, both formulas, a doctest example and the Ferro (2014) reference (QJRMS 140(683), 1917–1923, doi:10.1002/qj.2270).
- CHANGELOG entry under unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
